### PR TITLE
Fixed highlightClass being added to wrong element when hovering over child-element of item

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -303,7 +303,7 @@
                 if (lockMousover) {
                     return;
                 }
-                highlightItem($(e.target));
+                highlightItem($(e.currentTarget));
             });
 
             $sellecktEl.on('keyup', function(e){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -404,6 +404,9 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(liOne.hasClass(highlightClass)).toEqual(false);
                     expect(liTwo.hasClass(highlightClass)).toEqual(true);
 
+                    liTwo.children(':first').trigger('mouseover');
+                    expect(liTwo.children(':first').hasClass(highlightClass)).toEqual(false);
+                    expect(liTwo.hasClass(highlightClass)).toEqual(true);
                 });
                 it('removes the highlight class from all items when it closes', function(){
                     var highlightClass = selleckt.highlightClass;


### PR DESCRIPTION
Look at the [demo page](http://brandwatchltd.github.io/selleckt/demo/) of the plugin and try hovering over the _label_ of an item in the dropdown. Notice the highlighting disappears.

@grahamscott - Please review.
