### PR TITLE
Added proper clean up when plugin is destroyed

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -369,7 +369,7 @@
                 }
             });
 
-            $originalSelectEl.on('change', function(e) {
+            $originalSelectEl.on('change.selleckt', function(e) {
                 var newSelection = $(e.target).val();
                 self.updateSelection(newSelection);
             });
@@ -479,6 +479,8 @@
 
             //this.$originalSelectEl.after(this.$sellecktEl).show();
             this.$sellecktEl.off().remove();
+            this.$originalSelectEl.off('change.selleckt');
+            this.$originalSelectEl.removeData('selleckt').show();
         },
 
         _findMatchingOptions: function(items, term){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -785,6 +785,47 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 });
             });
         });
+
+        describe('removal', function(){
+            beforeEach(function(){
+                selleckt = Selleckt.create({
+                    mainTemplate : mainTemplate,
+                    $selectEl : $el
+                });
+                selleckt.render();
+            });
+            afterEach(function(){
+                selleckt = undefined;
+            });
+
+            it('removes change event from original select element', function(){
+                var eventsData = $._data(selleckt.$originalSelectEl[0], 'events');
+
+                expect(eventsData.change).toBeDefined();
+                expect(eventsData.change.length).toEqual(1);
+                expect(eventsData.change[0].namespace).toEqual('selleckt');
+
+                selleckt.destroy();
+
+                expect(eventsData.change).toEqual(undefined);
+            });
+
+            it('removes selleckt data from original select element', function(){
+                $el.data('selleckt', selleckt);
+
+                selleckt.destroy();
+
+                expect($el.data('selleckt')).toEqual(undefined);
+            });
+
+            it('shows original select element', function(){
+                expect($el.css('display')).toEqual('none');
+
+                selleckt.destroy();
+
+                expect($el.css('display')).toEqual('inline-block');
+            });
+        });
     });
 
     describe('multiselleckt', function(){


### PR DESCRIPTION
- remove change event handler bound to original select
- remove selleckt data from original select
- show original select

@grahamscott - Please review
