### PR TITLE
Made selleckt trigger change event on original select when selection is modified

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -369,7 +369,11 @@
                 }
             });
 
-            $originalSelectEl.on('change.selleckt', function(e) {
+            $originalSelectEl.on('change.selleckt', function(e, data) {
+                if(data && data.origin==='selleckt') {
+                    return;
+                }
+
                 var newSelection = $(e.target).val();
                 self.updateSelection(newSelection);
             });
@@ -433,7 +437,7 @@
             }
 
             this.selectedItem = item;
-            this.$originalSelectEl.val(item.value);
+            this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
 
             this.hideSelectionFromChoices();
 
@@ -595,7 +599,7 @@
     MultiSelleckt.prototype.updateOriginalSelect = function(){
         this.$originalSelectEl.val(_(this.getSelection()).map(function(item){
             return item.value;
-        }));
+        })).trigger('change', {origin: 'selleckt'});
     };
 
     MultiSelleckt.prototype.updateSelection = function(newSelection){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -515,6 +515,23 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                     expect(selleckt.getSelection().value).toEqual('2');
                 });
+                it('does not update selleckt when change on original select is triggered by selleckt itself', function(){
+                    selleckt.$originalSelectEl.val('2').trigger('change', {origin: 'selleckt'});
+
+                    expect(selleckt.getSelection().value).toEqual('1');
+                });
+                it('triggers a change event on original select when item is selected', function(){
+                    var changeHandler = sinon.spy();
+
+                    selleckt.$originalSelectEl.on('change', changeHandler);
+                    selleckt.selectItem('foo');
+
+                    expect(changeHandler.calledOnce).toEqual(true);
+                    expect(changeHandler.args[0].length).toEqual(2);
+                    expect(changeHandler.args[0][1].origin).toEqual('selleckt');
+
+                    selleckt.$originalSelectEl.off('change', changeHandler);
+                });
             });
 
             describe('Keyboard input', function(){
@@ -1223,6 +1240,18 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                 expect($selections.children().length).toEqual(1);
                 expect(multiSelleckt.$sellecktEl.find('.item[data-value="1"]').css('display')).not.toEqual('none');
+            });
+            it('triggers a change event on original select when item is removed', function(){
+                var changeHandler = sinon.spy();
+
+                multiSelleckt.$originalSelectEl.on('change', changeHandler);
+                $clickTarget.trigger('click');
+
+                expect(changeHandler.calledOnce).toEqual(true);
+                expect(changeHandler.args[0].length).toEqual(2);
+                expect(changeHandler.args[0][1].origin).toEqual('selleckt');
+
+                multiSelleckt.$originalSelectEl.off('change', changeHandler);
             });
         });
 


### PR DESCRIPTION
@grahamscott - Please review.

NB: When I'm triggering change on the original select I'm also passing in {origin: selleckt}. This is done so that we can determine which events where triggered by selleckt itself and avoid an event-loop. We don't want $originalSelectEl.on('change') to fire unless the event was triggered from "outside".

Hope that makes sense.
