### PR TITLE
Added user-configurable class names as tags to default templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following options can be passed to selleckt:
         <tr>
             <td>selectedTextClass</td>
             <td>string</td>
-            <td>-</td>
+            <td>selectedText</td>
             <td>
                 An element to show text (the placeholder, or the text of the current selection. This should be a child of the element defined in `selectedClass`.
             </td>
@@ -99,17 +99,25 @@ The following options can be passed to selleckt:
         <tr>
             <td>itemsClass</td>
             <td>string</td>
-            <td>-</td>
+            <td>items</td>
             <td>
                 The css class name for the container in which the available selections are shown.
             </td>
         </tr>
         <tr>
+            <td>itemslistClass</td>
+            <td>string</td>
+            <td>itemslist</td>
+            <td>
+                The css class name for the list of individual items.
+            </td>
+        </tr>
+        <tr>
             <td>itemClass</td>
             <td>string</td>
-            <td>-</td>
+            <td>item</td>
             <td>
-                The css class name for the container for an individual item. This should be a descendent of the `itemsClass` element.
+                The css class name for the container for an individual item. This should be a descendent of the `itemslistClass` element.
             </td>
         </tr>
         <tr>

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -90,19 +90,19 @@
     TEMPLATES = {
         SINGLE:
             '<div class="{{className}}" tabindex=1>' +
-                '<div class="selected">' +
-                    '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
+                '<div class="{{selectedClass}}">' +
+                    '<span class="{{selectedTextClass}}">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
                 '</div>' +
-                '<div class="items">' +
+                '<div class="{{itemsClass}}">' +
                     '{{#showSearch}}' +
                     '<div class="searchContainer">' +
-                        '<input class="search"></input>' +
+                        '<input class="{{searchInputClass}}"></input>' +
                     '</div>' +
                     '{{/showSearch}}' +
                     '<ul class="{{itemslistClass}}">' +
                         '{{#items}}' +
-                        '<li class="item" data-text="{{label}}" data-value="{{value}}">' +
-                            '<span class="itemText">{{label}}</span>' +
+                        '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+                            '<span class="{{itemTextClass}}">{{label}}</span>' +
                         '</li>' +
                         '{{/items}}' +
                     '</ul>' +
@@ -114,13 +114,13 @@
                 '{{#selections}}' +
                 '{{/selections}}' +
                 '</ul>' +
-                '<div class="selected">' +
-                    '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
+                '<div class="{{selectedClass}}">' +
+                    '<span class="{{selectedTextClass}}">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
                 '</div>' +
-                '<div class="items">' +
+                '<div class="{{itemsClass}}">' +
                     '<ul class="{{itemslistClass}}">' +
                     '{{#items}}' +
-                        '<li class="item" data-text="{{label}}" data-value="{{value}}">' +
+                        '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
                             '{{label}}' +
                         '</li>' +
                     '{{/items}}' +
@@ -574,7 +574,13 @@
                 showSearch : this.showSearch,
                 selectedItemText: selectedItem && selectedItem.label || this.placeholderText,
                 className : this.className,
+                selectedClass: this.selectedClass,
+                selectedTextClass: this.selectedTextClass,
+                itemsClass: this.itemsClass,
                 itemslistClass : this.itemslistClass,
+                itemClass: this.itemClass,
+                itemTextClass: this.itemTextClass,
+                searchInputClass: this.searchInputClass,
                 items: this.items
             });
         },

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -253,6 +253,32 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(templateData.items).toBeDefined();
                     expect(templateData.items.length).toEqual(3);
                 });
+                it('includes user configurable class names template data', function(){
+                    var templateData;
+
+                    selleckt = Selleckt.create({
+                        $selectEl: $el,
+                        className: 'selleckt',
+                        selectedClass: 'trigger',
+                        selectedTextClass: 'triggerText',
+                        itemsClass: 'dropdown',
+                        itemslistClass: 'options',
+                        itemClass: 'option',
+                        itemTextClass: 'optionText',
+                        searchInputClass: 'searchBox'
+                    });
+
+                    templateData = selleckt.getTemplateData();
+
+                    expect(templateData.className).toEqual('selleckt');
+                    expect(templateData.selectedClass).toEqual('trigger');
+                    expect(templateData.selectedTextClass).toEqual('triggerText');
+                    expect(templateData.itemsClass).toEqual('dropdown');
+                    expect(templateData.itemslistClass).toEqual('options');
+                    expect(templateData.itemClass).toEqual('option');
+                    expect(templateData.itemTextClass).toEqual('optionText');
+                    expect(templateData.searchInputClass).toEqual('searchBox');
+                });
             });
         });
 


### PR DESCRIPTION
A lot of CSS class names were configurable as options but weren't actually passed to the templates (nor were they available as tags in the default templates). I fixed that and also updated the readme.

@grahamscott: Please review.
