### PR TITLE
Add unique ids to scroll.selleckt events to prevent unintentional removal...

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -172,6 +172,8 @@
 
         this.showSearch = (settings.enableSearch &&
                             this.items.length > settings.searchThreshold);
+
+        this.id = _.uniqueId('selleckt');
     }
 
     function parseTemplate(template) {
@@ -235,7 +237,7 @@
 
             if(this._isOverflowing()) {
                 this._setItemsFixed();
-                this.$scrollingParent.one('scroll.selleckt', closeFunc);
+                this.$scrollingParent.one('scroll.selleckt.' + this.id, closeFunc);
                 return;
             }
 
@@ -262,7 +264,7 @@
             }
 
             $(document).off('click.selleckt', this._close);
-            this.$scrollingParent.off('scroll.selleckt');
+            this.$scrollingParent.off('scroll.selleckt.' + this.id);
         },
 
         _isOverflowing: function(){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -514,7 +514,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                         expect(eventsData.scroll).toBeDefined();
                         expect(eventsData.scroll.length).toEqual(1);
-                        expect(eventsData.scroll[0].namespace).toEqual('selleckt');
+                        expect(eventsData.scroll[0].namespace).toEqual('selleckt.' + selleckt.id);
                     });
                     it('calls "_close" when $scrollingParent is scrolled', function(){
                         var openSpy = sinon.spy(selleckt, '_open'),


### PR DESCRIPTION
...on _close (which happens if several selleckt instances have the same scrollingParent)

@grahamscott - Please review.
