### PR TITLE
Added user-configurable class names to item-/multi-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ An example basic template:
 An example template for multiselleckt:
 ````html
 <div class="{{className}}" tabindex=1>
-    <ul class="selections">
+    <ul class="{{selectionsClass}}">
     {{#selections}}
     {{/selections}}
     </ul>
@@ -300,7 +300,7 @@ An example template for multiselleckt:
 ````
 An example template for a multiselleckt item:
 ````html
-<li class="selectionItem" data-value="{{value}}">
-    {{text}}<i class="icon-remove remove"></i>
+<li class="{{selectionItemClass}}" data-value="{{value}}">
+    {{text}}<i class="icon-remove {{removeItemClass}}"></i>
 </li>
 ````

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -111,7 +111,7 @@
             '</div>',
         MULTI:
             '<div class="{{className}}" tabindex=1>' +
-                '<ul class="selections">' +
+                '<ul class="{{selectionsClass}}">' +
                 '{{#selections}}' +
                 '{{/selections}}' +
                 '</ul>' +
@@ -129,8 +129,8 @@
                 '</div>' +
             '</div>',
         MULTI_SELECTION:
-            '<li class="selectionItem" data-value="{{value}}">' +
-                '{{text}}<i class="icon-remove remove"></i>' +
+            '<li class="{{selectionItemClass}}" data-value="{{value}}">' +
+                '{{text}}<i class="icon-remove {{removeItemClass}}"></i>' +
             '</li>'
     };
 
@@ -761,6 +761,14 @@
         return this.selectedItems;
     };
 
+    MultiSelleckt.prototype.getTemplateData = function(){
+        var data = SingleSelleckt.prototype.getTemplateData.call(this);
+
+        return _.extend(data, {
+            selectionsClass: this.selectionsClass
+        });
+    };
+
     MultiSelleckt.prototype.parseItems = function($selectEl){
         var itemsObj = this._parseItemsFromOptions($selectEl);
 
@@ -803,11 +811,17 @@
         }, this);
     },
 
-    MultiSelleckt.prototype.buildItem = function(item){
-        var $html = $(this.selectionTemplate({
+    MultiSelleckt.prototype.getItemTemplateData = function(item){
+        return {
             text: item.label,
-            value: item.value
-        }));
+            value: item.value,
+            selectionItemClass: this.selectionItemClass,
+            removeItemClass: this.removeItemClass
+        };
+    },
+
+    MultiSelleckt.prototype.buildItem = function(item){
+        var $html = $(this.selectionTemplate(this.getItemTemplateData(item)));
 
         return $html.data('item', item);
     };

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -253,7 +253,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(templateData.items).toBeDefined();
                     expect(templateData.items.length).toEqual(3);
                 });
-                it('includes user configurable class names template data', function(){
+                it('includes user configurable class names in template data', function(){
                     var templateData;
 
                     selleckt = Selleckt.create({
@@ -1092,7 +1092,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     });
                 });
 
-                it('defaults this selectionsClass to "selections"',function(){
+                it('defaults this.selectionsClass to "selections"',function(){
                     expect(multiSelleckt.selectionsClass).toEqual('selections');
                 });
                 it('defaults this.selectionItemClass to "selectionItem"',function(){
@@ -1144,6 +1144,38 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 expect(multiSelleckt.$sellecktEl.find('.mySelectionItem').length).toEqual(2);
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(0).text()).toEqual('foo');
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(1).text()).toEqual('baz');
+            });
+        });
+
+        describe('template data', function(){
+            it('includes user configurable class name in main template data', function(){
+                var templateData;
+
+                multiSelleckt = Selleckt.create({
+                    multiple: true,
+                    $selectEl: $el,
+                    selectionsClass: 'selected-list'
+                });
+
+                templateData = multiSelleckt.getTemplateData();
+
+                expect(templateData.selectionsClass).toEqual('selected-list');
+            });
+
+            it('includes user configurable class names in item template data', function(){
+                var itemData;
+
+                multiSelleckt = Selleckt.create({
+                    multiple: true,
+                    $selectEl: $el,
+                    selectionItemClass: 'selected-item',
+                    removeItemClass: 'remove-selected'
+                });
+
+                itemData = multiSelleckt.getItemTemplateData(multiSelleckt.items[0]);
+
+                expect(itemData.selectionItemClass).toEqual('selected-item');
+                expect(itemData.removeItemClass).toEqual('remove-selected');
             });
         });
 


### PR DESCRIPTION
When I added the user-configurable classnames to the templates in PR #24 I missed the three classnames that are specific for multiselects. 

@grahamscott: Please review.
