### PR TITLE
don't fire change event on original select on instantiation

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -526,7 +526,7 @@
             this.items = itemsObj.items;
 
             if(itemsObj.selectedItems[0]){
-                this.selectItem(itemsObj.selectedItems[0]);
+                this.selectItem(itemsObj.selectedItems[0], { silent: true });
             }
         },
 
@@ -550,7 +550,9 @@
             }
         },
 
-        selectItem: function(item){
+        selectItem: function(item, options){
+            options = options || {};
+
             var selectedItem = this.selectedItem,
                 $sellecktEl = this.$sellecktEl;
 
@@ -564,7 +566,10 @@
             }
 
             this.selectedItem = item;
-            this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
+
+            if (!options.silent) {
+                this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
+            }
 
             this.hideSelectionFromChoices();
 

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -169,6 +169,27 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         });
                     });
                 });
+                describe('events', function(){
+                    it('does not trigger change event when instantiated on select with selected option', function(){
+                        var onChangeStub = sinon.stub();
+                        $el.on('change', onChangeStub);
+
+                        selleckt = Selleckt.create({
+                            mainTemplate: template,
+                            $selectEl : $el,
+                            className: 'selleckt',
+                            selectedClass: 'selected',
+                            selectedTextClass: 'selectedText',
+                            itemsClass: 'items',
+                            itemClass: 'item',
+                            selectedClassName: 'isSelected',
+                            highlightClass: 'isHighlighted'
+                        });
+
+                        expect(onChangeStub.called).toEqual(false);
+                        $el.off('change', onChangeStub);
+                    });
+                });
             });
 
             describe('template formats', function(){


### PR DESCRIPTION
Hi @grahamscott,

ran into an issue, because on instantiation selleckt will fire a change event on the original select element in case it has a selected option. I belief this to be a behavior not being expected.

If something else has already bound a change handler to the original select element, it will be called, although the value has not changed.

Please have a look at the fix
Thanks
