### PR TITLE
focus searchbox after the dropdown is positioned

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -228,7 +228,6 @@
             }
 
             this.$items.show();
-            this.$items.find('.'+this.searchInputClass).focus();
             this.$sellecktEl.addClass('open').removeClass('closed');
 
             closeFunc = _.bind(this._close, this);
@@ -238,10 +237,11 @@
             if(this._isOverflowing()) {
                 this._setItemsFixed();
                 this.$scrollingParent.one('scroll.selleckt.' + this.id, closeFunc);
-                return;
+            } else {
+                this._setItemsAbsolute();
             }
 
-            this._setItemsAbsolute();
+            this.$items.find('.'+this.searchInputClass).focus();
         },
 
         _close: function(event) {


### PR DESCRIPTION
Hi @grahamscott 

focusing before positioning the dropdown causes the ._setItemsFixed()
function to determine a wrong offset when opened for the first time.

This is because focus pushes the '.selected' container up before it is
shown.

If the search box is focused after the dropdown is correctly positioned
the issue is resolved.

Please review
Thanks
