### PR TITLE
keep selleckt focused after item is selected

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -390,7 +390,9 @@
                     self.selectItem(selectedItem);
                 }
 
-                return self._close();
+                self._close();
+
+                return $sellecktEl.focus();
             }
 
             function scrollItems(offset, absolute){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -797,6 +797,16 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                     expect(closeStub.calledOnce).toEqual(true);
                 });
+
+                it('resets focus to selleckt after item is selected', function(){
+                    var onFocusStub = sinon.stub();
+
+                    selleckt.$sellecktEl.focus(onFocusStub);
+                    $selectedItem.trigger(jQuery.Event('keydown', { which : KEY_CODES.DOWN }));
+                    $selectedItem.trigger(jQuery.Event('keydown', { which : KEY_CODES.ENTER }));
+
+                    expect(onFocusStub.calledOnce).toEqual(true);
+                });
             });
         });
 


### PR DESCRIPTION
Hi @grahamscott,
after a element is selected out of the dropdown (by mouse or enter key) the selleckt does not keep the focus.

Please review the change
Thanks
