### PR TITLE
fix search in IE8

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -517,8 +517,6 @@
                 });
 
                 $searchInput.on('keyup', _.debounce(function(e){
-                    e.stopPropagation();
-
                     var term = $searchInput.val();
 
                     filterOptions(term);


### PR DESCRIPTION
Hi @grahamscott

calling e.stopPropagation() debounced causes an exeption in IE8. Since
it is not needed here, remove it (details http://bugs.jquery.com/ticket/10004)

Can you also do a version bump?

Thanks
