### PR TITLE
Better support for options with empty values

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -558,7 +558,8 @@
             options = options || {};
 
             var selectedItem = this.selectedItem,
-                $sellecktEl = this.$sellecktEl;
+                $sellecktEl = this.$sellecktEl,
+                displayedLabel = item.label || this.placeholderText;
 
             if(selectedItem){
                 this.findItemInList(selectedItem).show();
@@ -566,7 +567,7 @@
 
             if($sellecktEl){
                 this.findItemInList(item).hide();
-                $sellecktEl.find('.'+this.selectedTextClass).text(item.label);
+                $sellecktEl.find('.'+this.selectedTextClass).text(displayedLabel);
             }
 
             this.selectedItem = item;

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -703,6 +703,24 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                     selleckt.$originalSelectEl.off('change', changeHandler);
                 });
+
+                describe('with an empty option', function(){
+                    beforeEach(function(){
+                        $el = $(elHtml).append('<option></option>').appendTo('body');
+                        selleckt = Selleckt.create({
+                            $selectEl : $el
+                        });
+
+                        selleckt.render();
+                    });
+
+                    it('displays the placeholder when the change event is triggered on the original select and its value is the empty string', function(){
+                        selleckt.$originalSelectEl.val('').trigger('change');
+                        var emptyOptionDisplayedText = selleckt.$sellecktEl.find('.selectedText').text();
+                        expect(emptyOptionDisplayedText).toEqual(selleckt.placeholderText);
+                    });
+                });
+
             });
 
             describe('Keyboard input', function(){


### PR DESCRIPTION
This PR addresses two separate issues.

1) If an `<option>` does not have an explicit `value` attribute, selleckt does not parse it correctly. See doc at http://www.w3.org/wiki/HTML/Elements/option#HTML_Attributes

2) As would be expected, if an option with an empty value is provided, selleckt displays a placeholder when said option is selected. If the underlying select tryggers a change event for that option though, the placeholder is lost.

Both issues are illustrated here: http://codepen.io/codazzo/pen/wnFsK
The solution can be seen working here: http://codepen.io/codazzo/pen/ErJcm
