### PR TITLE
Flip (fixed) items-dropdown on top of trigger when there's not enough space below

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -260,7 +260,7 @@
             this.$items.find('.'+this.highlightClass).removeClass(this.highlightClass);
             this.$items.find('.'+this.itemslistClass).scrollTop(0);
 
-            this.$items.hide();
+            this.$items.hide().removeClass('flipped');
             this.$sellecktEl.removeClass('open').addClass('closed');
 
             if(this.showSearch){
@@ -283,6 +283,37 @@
             return itemsBottom > overflowHiddenParentBottom;
         },
 
+        _flipIfNeeded: function() {
+            var $items = this.$items,
+                itemsHeight = $items.outerHeight(),
+                $window = $(window),
+                windowHeight = $window.height(),
+                scrollDistance = $window.scrollTop(),
+                dropdownBottom = $items.offset().top - scrollDistance + itemsHeight,
+                bottomSpace = windowHeight - dropdownBottom,
+                topSpace, $dropdownTrigger, triggerTop, newDropdownBottom;
+
+            if(bottomSpace > -1) { // there's enough space below the trigger
+                return;
+            }
+
+            $dropdownTrigger = this.$sellecktEl.find('.'+this.selectedClass);
+            triggerTop = $dropdownTrigger.offset().top - scrollDistance;
+            newDropdownBottom = windowHeight - triggerTop;
+            topSpace = windowHeight - (newDropdownBottom + itemsHeight);
+
+            if(topSpace < 0) { // don't go off screen on top
+                newDropdownBottom = newDropdownBottom + topSpace;
+            }
+
+            // when the dropdown is flipped it is positioned via 'bottom' rather than 'top' so that
+            // it won't "detach" from the trigger when the search is used and its height changes
+            $items.css({
+                top: 'auto',
+                bottom: newDropdownBottom
+            }).addClass('flipped');
+        },
+
         _setItemsFixed: function(){
             var $dropdownTrigger = this.$sellecktEl.find('.'+this.selectedClass),
                 $triggerOffset = $dropdownTrigger.offset(),
@@ -292,15 +323,19 @@
                 width: 'inherit',
                 position: 'fixed',
                 top: ($triggerOffset.top - $window.scrollTop() + $dropdownTrigger.outerHeight()) + 'px',
-                left: ($triggerOffset.left - $window.scrollLeft()) + 'px'
+                left: ($triggerOffset.left - $window.scrollLeft()) + 'px',
+                bottom: 'auto'
             });
+
+            this._flipIfNeeded();
         },
 
         _setItemsAbsolute: function(){
             this.$items.css({
                 position: 'absolute',
                 top: 'auto',
-                left: 'auto'
+                left: 'auto',
+                bottom: 'auto'
             });
         },
 

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -558,6 +558,51 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                         expect(eventsData).toBeUndefined();
                     });
+                    it('displays fixed items container below the trigger', function(){
+                        // move selleckt to top so there's enough room for the dropdown
+                        selleckt.$sellecktEl.css({
+                            position:'absolute', top:0
+                        });
+
+                        selleckt._open();
+
+                        expect(selleckt.$items.offset().top).toEqual(selleckt.$sellecktEl.find('.selected').offset().top + selleckt.$sellecktEl.find('.selected').outerHeight());
+                        expect(selleckt.$items.hasClass('flipped')).toEqual(false);
+                    });
+                    it('displays fixed items container on top if there\'s not enough space below the trigger', function(){
+                        // create testarea that stretches to the bottom of the screen
+                        var $testArea = $('<div class="testarea">').css({
+                            position:'fixed', top:0, left:0, width:'100%', height:'100%'
+                        }).appendTo('body');
+
+                        // position selleckt in testarea to force the dropdown to go off screen
+                        selleckt.$sellecktEl.css({
+                            position:'absolute', bottom:0, height: '20px', overflow:'hidden'
+                        }).appendTo($testArea);
+
+                        selleckt._open();
+
+                        expect(selleckt.$items.offset().top + selleckt.$items.outerHeight()).toEqual(selleckt.$sellecktEl.find('.selected').offset().top);
+                        expect(selleckt.$items.hasClass('flipped')).toEqual(true);
+
+                        // clean up
+                        $testArea.remove();
+                    });
+                    it('removes "flipped" class from this.$items on _close when the dropdown was displayed on top', function(){
+                        var flipStub = sinon.stub(selleckt, '_flipIfNeeded', function() {
+                            selleckt.$items.addClass('flipped');
+                        });
+
+                        selleckt._open();
+
+                        expect(selleckt.$items.hasClass('flipped')).toEqual(true);
+
+                        selleckt._close();
+
+                        expect(selleckt.$items.hasClass('flipped')).toEqual(false);
+
+                        flipStub.restore();
+                    });
                 });
             });
 


### PR DESCRIPTION
This change flips the items dropdown on top of the select when there is not enough space to fold it out below. The change is only needed for cases where the dropdown has a `fixed` position. For cases where the dropdown position is `absolute` there will be a parent element that is either scrollable or has `overflow:visible`. (See here for a demo of the problem with the fixed dropdown: http://jsbin.com/UnOmIKI)

@grahamscott - Please review.

Thanks
