### PR TITLE
Fix XSS a different way

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -346,13 +346,7 @@
                 var $option = $(option),
                     item = {
                         value: $option.val(),
-                        // Use .html() for XSS protection - yes, counter-intuitive, but:
-                        // We can relatively safely assume that the content of the <option> is already escaped
-                        // (because we're using mustache)
-                        // So using text() would return *unescaped* HTML
-                        // Then when we do the filtering in filterOptions and set .html() we end up injecting 
-                        // unescaped HTML into the page
-                        label: $option.html(),
+                        label: $option.text(),
                         data: $option.data()
                     };
 
@@ -740,11 +734,11 @@
                     return;
                 }
 
-                html = item.label.substring(0, item.matchStart) +
+                html = _.escape(item.label.substring(0, item.matchStart)) +
                         markStart +
-                        item.label.slice(item.matchStart, item.matchEnd + 1) +
+                        _.escape(item.label.slice(item.matchStart, item.matchEnd + 1)) +
                         markEnd +
-                        item.label.substring(item.matchEnd + 1);
+                        _.escape(item.label.substring(item.matchEnd + 1));
 
                 $textContainer.html(html);
 


### PR DESCRIPTION
This undoes my last PR and does the escaping of search results in filterOptions.

My last fix doesn't work when selleckt doesn't have a search box, because then the
option text is passed into mustache, which will double-escape the already escaped text
