### PR TITLE
Preventing selection of current item were it to be made visible

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -428,6 +428,9 @@
                     selectedItem = self.findItem(highlightItem.data('value'));
 
                 if(selectedItem){
+                    if(self.selectedItem && self.selectedItem.value === selectedItem.value){
+                        return;
+                    }
                     self.selectItem(selectedItem);
                 }
 

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -683,6 +683,16 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 it('hides the selected item from the list', function(){
                     expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
                 });
+                it('does not trigger an event when the selected item is clicked, were it to be unhidden', function(){
+                    var spy = sinon.spy(),
+                        $selectedItem = selleckt.$items.find('.item[data-value="1"]');
+
+                    selleckt.bind('itemSelected', spy);
+
+                    $selectedItem.css('display', 'block').trigger('mouseover').trigger('click');
+
+                    expect(spy.called).toEqual(false);
+                });
                 it('shows the previously-selected item in the list', function(){
                     expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
 


### PR DESCRIPTION
This PR prevents the currently selected item from responding to clicks - normally the item isn't visible, in which case such code isn't necessary, but if the item is made visible (e.g. via a post-render hook or something similar) then this code is necessary.
