### PR TITLE
Adding close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ The following events are raised by an instance of selleckt:
     </thead>
     <tbody>
         <tr>
+            <td>close</td>
+            <td>-</td>
+            <td>Triggered when selleckt's dropdown closes</td>
+        </tr>
+        <tr>
             <td>itemSelected</td>
             <td>The item that the user has selected</td>
             <td>Triggered each time an option is selected by the user. An item is an object representing an option in the selleckt, consisting of value, label and data properties.</td>

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -271,6 +271,8 @@
 
             $(document).off('click.selleckt-' + this.id);
             this.$scrollingParent.off('scroll.selleckt-' + this.id);
+
+            this.trigger('close');
         },
 
         _isOverflowing: function(){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -470,6 +470,16 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(openSpy.calledOnce).toEqual(true);
                     expect(closeSpy.calledOnce).toEqual(true);
                 });
+                it('triggers a "close" event when _close is called', function(){
+                    var listener = sinon.stub();
+
+                    selleckt.bind('close', listener);
+                    selleckt._close();
+
+                    expect(listener.calledOnce).toEqual(true);
+
+                    selleckt.unbind('close', listener);
+                });
                 it('adds a class of "open" to this.$sellecktEl when the selleckt is opened', function(){
                     selleckt._open();
 


### PR DESCRIPTION
This is branched from my other PR about adding an optionsFiltered event (https://github.com/BrandwatchLtd/selleckt/pull/49) which at the time of writing is open, hence why there are a few commits here not directly related to the close event.

This PR adds a "close" event, which is triggered when selleckt's dropdown is closed - this makes it easy to hook on behaviour like having the whole selleckt disappear when it closes.
