### PR TITLE
Trigger itemRemoved on MultiSelleckt item removal

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -903,6 +903,8 @@
         this.updateOriginalSelect();
 
         this.toggleDisabled();
+
+        this.trigger('itemRemoved', item);
     };
 
     MultiSelleckt.prototype.toggleDisabled = function(){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -1686,6 +1686,19 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                 multiSelleckt.$originalSelectEl.off('change', changeHandler);
             });
+            it('triggers an "itemRemoved" event with the removed item', function(){
+                var spy = sinon.spy();
+
+                multiSelleckt.bind('itemRemoved', spy);
+                $clickTarget.trigger('click');
+
+                expect(spy.calledOnce).toEqual(true);
+                expect(spy.args[0][0]).toEqual({
+                    value: '1',
+                    label: 'foo',
+                    data: {}
+                });
+            });
         });
 
         describe('events', function(){


### PR DESCRIPTION
I've added an `itemRemoved` event that's fired upon an item being removed from a `MultiSelleckt`. 

I'm currently using the event `itemSelected` to monitor the MultiSelleckt for new items, but the lack of an opposite event is causing me problems. This PR simply addresses the imbalance.

Thanks very much!
