### PR TITLE
No longer selecting first item by default

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -352,7 +352,7 @@
                         data: $option.data()
                     };
 
-                if($option.is(':selected')){
+                if($option.attr('selected')){
                     memo.selectedItems.push(item);
                 }
 

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -168,7 +168,45 @@ define(['lib/selleckt', 'lib/mustache.js'],
                             data: {}
                         });
                     });
+
+                    describe('when there is no selected item already', function(){
+                        var $newEl;
+
+                        beforeEach(function(){
+                            var selectHtml = '<select>' +
+                            '<option value="1">foo</option>' +
+                            '<option value="2">bar</option>' +
+                            '<option value="3">baz</option>' +
+                            '</select>';
+
+                            selleckt.destroy();
+
+                            $newEl = $(selectHtml).appendTo('body');
+
+                            selleckt = Selleckt.create({
+                                mainTemplate: template,
+                                $selectEl : $newEl,
+                                className: 'selleckt',
+                                selectedClass: 'selected',
+                                selectedTextClass: 'selectedText',
+                                itemsClass: 'items',
+                                itemClass: 'item',
+                                selectedClassName: 'isSelected',
+                                highlightClass: 'isHighlighted'
+                            });
+                        });
+
+                        afterEach(function(){
+                            $newEl.remove();
+                            $newEl = undefined;
+                        });
+
+                        it('does not select an item', function(){
+                            expect(selleckt.selectedItem).toBeUndefined();
+                        });
+                    });
                 });
+
                 describe('events', function(){
                     it('does not trigger change event when instantiated on select with selected option', function(){
                         var onChangeStub = sinon.stub();


### PR DESCRIPTION
This stops selleckt from selecting the first option by default - instead, it will only select items which explicitly have the "selected" attribute set. As such, if no option is marked as selected then nothing will be selected and the placeholder text will be visible.

I think the existing behaviour carries over from standard select elements, but it doesn't feel that natural in the context of Selleckt - and having to put an empty option at the top of the list feels like a bit of a fudge, given that placeholders aren't handled as options.

Although this didn't break any tests it _has_ changed the behaviour - the first two examples on the demo page now default to showing a placeholder, rather than selecting "Foo". Although I think this is a better default behaviour for most cases, I suppose I could always make this a setting that has to be turned on, if preferable?

I think this addresses this issue: https://github.com/BrandwatchLtd/selleckt/issues/54
