### PR TITLE
Allowing event propgation and default behaviour on mouse scrolling

### DIFF
--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -22,7 +22,7 @@
     */
 
     var MicroEvent  = function(){};
-    MicroEvent.prototype    = {
+    MicroEvent.prototype = {
         bind    : function(event, fct){
             this._events = this._events || {};
             this._events[event] = this._events[event]   || [];
@@ -391,6 +391,13 @@
                                 ev.originalEvent.wheelDelta),
                         up = delta > 0,
                         prevent = function() {
+                            function isOpen(el){
+                                return $(el).parents('.selleckt').hasClass('open');
+                            }
+
+                            if(!isOpen(ev.target)) {
+                                return;
+                            }
                             ev.stopPropagation();
                             ev.preventDefault();
                             ev.returnValue = false;


### PR DESCRIPTION
This change stops multiple selleckts from preventing the user scrolling the element behind, on when the multiple selleckt element is closed.

Waiting for:

 - [x] QA