### PR TITLE
Selleckt async

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
         },
         shell: {
             runLocalTests: {
-                command: './testem -l Firefox,PhantomJS'
+                command: './testem -l Firefox'
             }
         },
         'saucelabs-mocha': {

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ For multiselleckts, in addition to the above:
             </td>
         </tr>
         <tr>
-            <td>removeItemClass</td>
+            <td>unselectItemClass</td>
             <td>string</td>
             <td>
-                remove
+                unselect
             </td>
             <td>
                 Css class of the element used to trigger removal of a selectionItemClass element from the selectionsClass container.
@@ -305,7 +305,7 @@ An example template for multiselleckt:
 An example template for a multiselleckt item:
 ````html
 <li class="{{selectionItemClass}}" data-value="{{value}}">
-    {{text}}<i class="icon-remove {{removeItemClass}}"></i>
+    {{text}}<i class="icon-remove {{unselectItemClass}}"></i>
 </li>
 ````
 

--- a/demo/css/selleckt.css
+++ b/demo/css/selleckt.css
@@ -148,6 +148,9 @@
 .demo-4 .selleckt ul.selections li > div {
     margin: 0 30px 2px 0;
 }
+.demo-5 button {
+    margin-top: 10px;
+}
 .selleckt .selections i {
     position: absolute;
     top: 8px;

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,14 @@
         <script src="lib/jquery-1.10.1.js"></script>
         <script src="lib/underscore.js"></script>
         <script src="lib/mustache.js"></script>
+
+         <!--[if IE 8 ]>
         <script src="../shims/object-create-shim.js"></script>
+        <script src="../shims/es5-shim.min.js"></script>
+        <![endif]-->
+
+        <script src="../shims/mutationobserver-shim.js"></script>
+
         <script src="../lib/selleckt.js"></script>
 
         <style>
@@ -111,6 +118,16 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                 <button id="addButton">Click me!</button>
                 <input type="checkbox" id="select-immediately"></input><label for="select-immediately">Select the new item immediately</label>
             </div>
+            <div class="demo demo-6">
+                <h2>Removing items</h2>
+                <p>Click the button to remove the "Baz" item</p>
+                <select id="demo-6">
+                    <option value="1">Foo</option>
+                    <option value="2">Bar</option>
+                    <option value="3">Baz</option>
+                </select>
+                <button id="removeButton">Click me!</button>
+            </div>
         </div>
         <script id="fancyTemplate" type="text/html">
             <div class="{{className}}" tabindex=1>
@@ -155,6 +172,7 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     $select3 = $('#demo-3'),
                     $select4 = $('#demo-4'),
                     $select5 = $('#demo-5'),
+                    $select6 = $('#demo-6'),
                     fancyTemplate = document.getElementById('fancyTemplate').innerHTML,
                     fancySelectionTemplate = document.getElementById('fancySelectionTemplate').innerHTML;
 
@@ -196,6 +214,11 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                         value: 'wheee!',
                         isSelected: selectNewItem
                     });
+                });
+
+                $select6.selleckt();
+                $('.demo-6 #removeButton').click(function (){
+                    $select6.data('selleckt').removeItem('3');
                 });
             });
         </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -147,6 +147,8 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
             </li>
         </script>
         <script>
+            'use strict';
+            /*global $:true alert:true*/
             $(function(){
                 var $select1 = $('#demo-1'),
                     $select2 = $('#demo-2'),
@@ -174,7 +176,7 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     .on('click', '.add', function(e){
                         e.preventDefault();
                         e.stopPropagation();
-                        alert('Hey, you clicked the "add button"');
+                        window.alert('Hey, you clicked the "add button"');
                     })
                     .on('click', '.edit', function(e){
                         e.preventDefault();
@@ -182,11 +184,11 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
 
                         var item = $(e.target).closest('.selectionItem').data('item');
 
-                        alert('Hey, you clicked the "edit button" for item: ' + JSON.stringify(item));
+                        window.alert('Hey, you clicked the "edit button" for item: ' + JSON.stringify(item));
                     });
 
                 $select5.selleckt();
-                $('.demo-5 #addButton').click(function (e){
+                $('.demo-5 #addButton').click(function (){
                     var selectNewItem = $('.demo-5 #select-immediately').is(':checked');
 
                     $select5.data('selleckt').addItem({

--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,17 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     <option value="3">Baz</option>
                 </select>
             </div>
+            <div class="demo demo-5">
+                <h2>Adding items</h2>
+                <p>Click the button to add a new item</p>
+                <select id="demo-5">
+                    <option value="1">Foo</option>
+                    <option value="2">Bar</option>
+                    <option value="3">Baz</option>
+                </select>
+                <button id="addButton">Click me!</button>
+                <input type="checkbox" id="select-immediately"></input><label for="select-immediately">Select the new item immediately</label>
+            </div>
         </div>
         <script id="fancyTemplate" type="text/html">
             <div class="{{className}}" tabindex=1>
@@ -141,6 +152,7 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     $select2 = $('#demo-2'),
                     $select3 = $('#demo-3'),
                     $select4 = $('#demo-4'),
+                    $select5 = $('#demo-5'),
                     fancyTemplate = document.getElementById('fancyTemplate').innerHTML,
                     fancySelectionTemplate = document.getElementById('fancySelectionTemplate').innerHTML;
 
@@ -172,6 +184,17 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
 
                         alert('Hey, you clicked the "edit button" for item: ' + JSON.stringify(item));
                     });
+
+                $select5.selleckt();
+                $('.demo-5 #addButton').click(function (e){
+                    var selectNewItem = $('.demo-5 #select-immediately').is(':checked');
+
+                    $select5.data('selleckt').addItem({
+                        label: 'New item!',
+                        value: 'wheee!',
+                        isSelected: selectNewItem
+                    });
+                });
             });
         </script>
     </body>

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -396,13 +396,11 @@
             return $option;
         },
 
-        _addItemToSelleckt: function(item){
-            var renderedItem = Mustache.render(this.itemTemplate, _.extend({
-                    itemClass: this.itemClass,
-                    itemTextClass: this.itemTextClass,
-                }, item));
-
-            this.$sellecktEl.find('.' + this.itemslistClass).append(renderedItem);
+        _createSellecktItem: function(item){
+            return Mustache.render(this.itemTemplate, _.extend({
+                itemClass: this.itemClass,
+                itemTextClass: this.itemTextClass,
+            }, item));
         },
 
         _removeItemFromSelleckt: function(item){

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -138,6 +138,9 @@
             '</li>'
     };
 
+    var IS_MUTATION_OBSERVER_SHIMMED = window.MutationObserver && window.MutationObserver._period;
+    var DELAY_TIMEOUT = IS_MUTATION_OBSERVER_SHIMMED ? window.MutationObserver._period : 0;
+
     function SingleSelleckt(options){
         var settings = _.defaults(options, {
             mainTemplate: TEMPLATES.SINGLE,
@@ -223,12 +226,20 @@
     }
 
     function itemsFromNodes(nodeList){
-        return Array.prototype.map.call(nodeList, function(node){
+        return _.map(nodeList, function(node){
             return {
                 value: node.value,
                 label: node.text,
                 isSelected: node.selected
             };
+        });
+    }
+
+    function objectIntersect(arr1, arr2){
+        return _.filter(arr1, function(item){
+            return !(_.any(arr2, function(otherItem){
+                return _.isEqual(item, otherItem);
+            }));
         });
     }
 
@@ -404,22 +415,47 @@
         },
 
         _observeMutations: function(element){
-            var createSellecktItem = this._createSellecktItem.bind(this),
+            var createSellecktItem = _.bind(this._createSellecktItem, this),
                 $items = this.$sellecktEl.find('.' + this.itemslistClass),
+                findItemInList = _.bind(this.findItemInList, this),
                 observer;
 
             // create an observer instance
             observer = this.mutationObserver = new MutationObserver(function mutationHandler(mutations){
                 var newItems = [];
+                var removedItems = [];
 
-                mutations.forEach(function(mutation) {
-                    newItems = newItems.concat(_.map(itemsFromNodes(mutation.addedNodes), createSellecktItem));
+                _.each(mutations, function(mutation) {
+                    newItems = newItems.concat(itemsFromNodes(mutation.addedNodes));
+                    removedItems = removedItems.concat(itemsFromNodes(mutation.removedNodes));
                 });
 
-                $items.append(newItems);
+                //the Mutation Observer shim sometimes gets confused when removing nodes
+                //let's double check that the nodes are indeed removed (otherwise they
+                //appear in the newItems array too)
+                if(IS_MUTATION_OBSERVER_SHIMMED){
+                    var trulyRemoved = objectIntersect(removedItems, newItems);
+                    var trulyNew = objectIntersect(newItems, removedItems);
+
+                    removedItems = trulyRemoved;
+                    newItems = trulyNew;
+                }
+
+                $items.append(_.map(newItems, createSellecktItem));
+
+                _.each(removedItems, function(item){
+                    findItemInList(item).remove();
+                });
             });
 
-            observer.observe(element, {childList: true});
+            observer.observe(element, {
+                childList: true,
+                attributes: false,
+                characterData: false,
+                subtree: false,
+                attributeOldValue: false,
+                characterDataOldvalue: false
+            });
         },
 
         _stopObservingMutations: function(){
@@ -516,7 +552,8 @@
                 } else {
                     $items[0].scrollTop += offset;
                 }
-                setTimeout(function(){
+
+                _.delay(function(){
                     lockMousover = false;
                 }, 200);
             }
@@ -718,7 +755,7 @@
         },
 
         addItems: function(items){
-            var selectItem = this.selectItem.bind(this);
+            var selectItem = _.bind(this.selectItem, this);
             var $options = _.map(items, function(item){
                 return this._createOptionFromItem(item);
             }, this);
@@ -735,14 +772,14 @@
                 return;
             }
 
-            _.defer(function(){
+            _.delay(function(){
                 selectItem(selectedItem);
-            });
+            }, DELAY_TIMEOUT);
         },
 
         addItem: function(item){
             var $option = this._createOptionFromItem(item);
-            var selectItem = this.selectItem.bind(this);
+            var selectItem = _.bind(this.selectItem, this);
 
             $option.appendTo(this.$originalSelectEl);
 
@@ -755,9 +792,23 @@
             //defer this because we hook into the mutation
             //event in order to populate Selleckt, and that
             //event fires asynchronously
-            _.defer(function(){
+            _.delay(function(){
                 selectItem(item);
+            }, DELAY_TIMEOUT);
+        },
+
+        removeItem: function(value){
+            this.items = _.filter(this.items, function(item){
+                /*jshint eqeqeq:false*/
+                return item.value != value;
             });
+
+            if(this.selectedItem && this.selectedItem.value === value){
+                this.selectedItem = undefined;
+                this.$sellecktEl.find('.'+this.selectedTextClass).text(this.placeholderText);
+            }
+
+            this.$originalSelectEl.find('option[value="' + value +'"]').remove();
         },
 
         render: function(){

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -403,30 +403,23 @@
             }, item));
         },
 
-        _removeItemFromSelleckt: function(item){
-            console.log('_removeItemFromSelleckt', item);
-        },
-
         _observeMutations: function(element){
-            var addItemToSelleckt = this._addItemToSelleckt.bind(this);
-            var removeItemFromSelleckt = this._removeItemFromSelleckt.bind(this);
-
-            function mutationHandler(mutations){
-                mutations.forEach(function(mutation) {
-                    itemsFromNodes(mutation.addedNodes).forEach(addItemToSelleckt);
-                    itemsFromNodes(mutation.removedNodes).forEach(removeItemFromSelleckt);
-                });
-            }
+            var createSellecktItem = this._createSellecktItem.bind(this),
+                $items = this.$sellecktEl.find('.' + this.itemslistClass),
+                observer;
 
             // create an observer instance
-            var observer = this.mutationObserver = new MutationObserver(mutationHandler),
-                config = {
-                    attributes: true,
-                    childList: true,
-                    characterData: true
-                };
+            observer = this.mutationObserver = new MutationObserver(function mutationHandler(mutations){
+                var newItems = [];
 
-            observer.observe(element, config);
+                mutations.forEach(function(mutation) {
+                    newItems = newItems.concat(_.map(itemsFromNodes(mutation.addedNodes), createSellecktItem));
+                });
+
+                $items.append(newItems);
+            });
+
+            observer.observe(element, {childList: true});
         },
 
         _stopObservingMutations: function(){
@@ -724,6 +717,29 @@
             });
         },
 
+        addItems: function(items){
+            var selectItem = this.selectItem.bind(this);
+            var $options = _.map(items, function(item){
+                return this._createOptionFromItem(item);
+            }, this);
+
+            this.$originalSelectEl.append($options);
+
+            this.items = this.items.concat(items);
+
+            var selectedItem = _.find(items, function(item){
+                return item.isSelected;
+            });
+
+            if(!selectedItem){
+                return;
+            }
+
+            _.defer(function(){
+                selectItem(selectedItem);
+            });
+        },
+
         addItem: function(item){
             var $option = this._createOptionFromItem(item);
             var selectItem = this.selectItem.bind(this);
@@ -742,14 +758,6 @@
             _.defer(function(){
                 selectItem(item);
             });
-        },
-
-        removeItem: function(item){
-            if(item.isSelected){
-                this.selectedItem = undefined;
-            }
-
-            console.log('remove item', arguments);
         },
 
         render: function(){

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -782,6 +782,8 @@
                 return;
             }
 
+            this._stopObservingMutations();
+
             $(document).off('click.selleckt-' + this.id);
             this.$scrollingParent.off('scroll.selleckt-' + this.id);
 

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -134,7 +134,7 @@
             '</li>',
         MULTI_SELECTION:
             '<li class="{{selectionItemClass}}" data-value="{{value}}">' +
-                '{{text}}<i class="icon-remove {{removeItemClass}}"></i>' +
+                '{{text}}<i class="icon-remove {{unselectItemClass}}"></i>' +
             '</li>'
     };
 
@@ -885,7 +885,7 @@
         this.alternatePlaceholder = options.alternatePlaceholder || 'Select another...';
         this.selectionsClass = options.selectionsClass || 'selections';
         this.selectionItemClass = options.selectionItemClass || 'selectionItem';
-        this.removeItemClass = options.removeItemClass || 'remove';
+        this.unselectItemClass = options.unselectItemClass || 'unselect';
         this.showEmptyList = options.showEmptyList || false;
 
         SingleSelleckt.call(this, options);
@@ -933,7 +933,7 @@
         });
 
         _(itemsToRemove).each(function(value) {
-            self.removeItem(self.findItem(value));
+            self.unselectItem(self.findItem(value));
         });
     };
 
@@ -970,16 +970,16 @@
     };
 
     MultiSelleckt.prototype.bindEvents = function(){
-        var removeItem = _.bind(this.removeItem, this),
+        var unselectItem = _.bind(this.unselectItem, this),
             selectionItemClass = this.selectionItemClass;
 
-        this.$sellecktEl.on('click', '.'+this.removeItemClass, function(e){
+        this.$sellecktEl.on('click', '.'+this.unselectItemClass, function(e){
             e.preventDefault();
             e.stopPropagation();
 
             var $item = $(e.target).closest('.'+selectionItemClass);
 
-            removeItem($item.data('item'));
+            unselectItem($item.data('item'));
         });
 
         SingleSelleckt.prototype.bindEvents.call(this);
@@ -996,7 +996,7 @@
             text: item.label,
             value: item.value,
             selectionItemClass: this.selectionItemClass,
-            removeItemClass: this.removeItemClass,
+            unselectItemClass: this.unselectItemClass,
             data: item.data
         };
     };
@@ -1010,7 +1010,7 @@
         return $html.data('item', item);
     };
 
-    MultiSelleckt.prototype.removeItem = function(item){
+    MultiSelleckt.prototype.unselectItem = function(item){
         this.$selections.find('[data-value="' + item.value +'"]').remove();
 
         this.findItemInList(item).show();
@@ -1027,7 +1027,7 @@
 
         this.toggleDisabled();
 
-        this.trigger('itemRemoved', item);
+        this.trigger('itemUnselected', item);
     };
 
     MultiSelleckt.prototype.toggleDisabled = function(){

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -102,13 +102,15 @@
                     '{{/showSearch}}' +
                     '<ul class="{{itemslistClass}}">' +
                         '{{#items}}' +
-                        '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
-                            '<span class="{{itemTextClass}}">{{label}}</span>' +
-                        '</li>' +
+                            '{{> item}}' +
                         '{{/items}}' +
                     '</ul>' +
                 '</div>' +
             '</div>',
+        SINGLE_ITEM:
+            '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+                '<span class="{{itemTextClass}}">{{label}}</span>' +
+            '</li>',
         MULTI:
             '<div class="{{className}}" tabindex=1>' +
                 '<ul class="{{selectionsClass}}">' +
@@ -121,13 +123,15 @@
                 '<div class="{{itemsClass}}">' +
                     '<ul class="{{itemslistClass}}">' +
                     '{{#items}}' +
-                        '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
-                            '{{label}}' +
-                        '</li>' +
+                        '{{> item}}' +
                     '{{/items}}' +
                     '</ul>' +
                 '</div>' +
             '</div>',
+        MULTI_ITEM:
+            '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+                '{{label}}' +
+            '</li>',
         MULTI_SELECTION:
             '<li class="{{selectionItemClass}}" data-value="{{value}}">' +
                 '{{text}}<i class="icon-remove {{removeItemClass}}"></i>' +
@@ -137,6 +141,7 @@
     function SingleSelleckt(options){
         var settings = _.defaults(options, {
             mainTemplate: TEMPLATES.SINGLE,
+            itemTemplate: TEMPLATES.SINGLE_ITEM,
             mainTemplateData: {},
             selectedClass : 'selected',
             selectedTextClass : 'selectedText',
@@ -155,6 +160,7 @@
         this.$originalSelectEl = options.$selectEl;
 
         this.mainTemplate = this.mainTemplate || parseTemplate(settings.mainTemplate);
+        this.itemTemplate = this.itemTemplate || parseTemplate(settings.itemTemplate);
         this.mainTemplateData = settings.mainTemplateData;
         this.selectedClass = settings.selectedClass;
         this.selectedTextClass = settings.selectedTextClass;
@@ -177,13 +183,12 @@
     }
 
     function parseTemplate(template) {
-        if (typeof(template) === 'function') {
+        if (typeof(template) === 'string') {
+            Mustache.parse(template);
             return template;
-        } else if (typeof(template) === 'string') {
-            return Mustache.compile(template);
-        } else {
-            throw new Error('Please provide a valid mustache template.');
         }
+
+        throw new Error('Please provide a valid mustache template.');
     }
 
     function getScrollingParent($el){
@@ -658,11 +663,15 @@
 
         render: function(){
             var templateData = this.getTemplateData(),
-                $sellecktEl = this.$sellecktEl = $(this.mainTemplate(templateData)).addClass('closed');
+                $originalSelectEl = this.$originalSelectEl,
+                rendered = Mustache.render(this.mainTemplate, templateData, {
+                    item: this.itemTemplate
+                }),
+                $sellecktEl = this.$sellecktEl = $(rendered).addClass('closed');
 
-            this.$items = $sellecktEl.find('.items');
+            this.$items = $sellecktEl.find('.'+this.itemsClass);
 
-            this.$originalSelectEl.hide().before($sellecktEl);
+            $originalSelectEl.hide().before($sellecktEl);
 
             this.$scrollingParent = getScrollingParent($sellecktEl);
 
@@ -767,6 +776,7 @@
 
     function MultiSelleckt(options){
         this.mainTemplate = parseTemplate(options.mainTemplate || TEMPLATES.MULTI);
+        this.itemTemplate = parseTemplate(options.itemTemplate || TEMPLATES.MULTI_ITEM);
         this.selectionTemplate = parseTemplate(options.selectionTemplate || TEMPLATES.MULTI_SELECTION);
 
         this.alternatePlaceholder = options.alternatePlaceholder || 'Select another...';
@@ -889,7 +899,10 @@
     };
 
     MultiSelleckt.prototype.buildItem = function(item){
-        var $html = $(this.selectionTemplate(this.getItemTemplateData(item)));
+        var rendered = Mustache.render(this.selectionTemplate, this.getItemTemplateData(item), {
+                item: this.itemTemplate
+            }),
+            $html = $(rendered);
 
         return $html.data('item', item);
     };

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -222,6 +222,16 @@
         return $overflowHiddenParent;
     }
 
+    function itemsFromNodes(nodeList){
+        return Array.prototype.map.call(nodeList, function(node){
+            return {
+                value: node.value,
+                label: node.text,
+                isSelected: node.selected
+            };
+        });
+    }
+
     _.extend(SingleSelleckt.prototype, {
 
         _open: function() {
@@ -368,6 +378,61 @@
                 items: [],
                 selectedItems: []
             });
+        },
+
+        _createOptionFromItem: function(item){
+            var $option = $('<option>', {
+                selected: item.isSelected,
+                value: item.value,
+                text: item.label
+            });
+
+            if(item.data){
+                Object.keys(item.data).forEach(function(key){
+                    $option.attr('data-' + key, item.data[key]);
+                });
+            }
+
+            return $option;
+        },
+
+        _addItemToSelleckt: function(item){
+            var renderedItem = Mustache.render(this.itemTemplate, _.extend({
+                    itemClass: this.itemClass,
+                    itemTextClass: this.itemTextClass,
+                }, item));
+
+            this.$sellecktEl.find('.' + this.itemslistClass).append(renderedItem);
+        },
+
+        _removeItemFromSelleckt: function(item){
+            console.log('_removeItemFromSelleckt', item);
+        },
+
+        _observeMutations: function(element){
+            var addItemToSelleckt = this._addItemToSelleckt.bind(this);
+            var removeItemFromSelleckt = this._removeItemFromSelleckt.bind(this);
+
+            function mutationHandler(mutations){
+                mutations.forEach(function(mutation) {
+                    itemsFromNodes(mutation.addedNodes).forEach(addItemToSelleckt);
+                    itemsFromNodes(mutation.removedNodes).forEach(removeItemFromSelleckt);
+                });
+            }
+
+            // create an observer instance
+            var observer = this.mutationObserver = new MutationObserver(mutationHandler),
+                config = {
+                    attributes: true,
+                    childList: true,
+                    characterData: true
+                };
+
+            observer.observe(element, config);
+        },
+
+        _stopObservingMutations: function(){
+            this.mutationObserver.disconnect();
         },
 
         bindEvents: function(){
@@ -661,6 +726,34 @@
             });
         },
 
+        addItem: function(item){
+            var $option = this._createOptionFromItem(item);
+            var selectItem = this.selectItem.bind(this);
+
+            $option.appendTo(this.$originalSelectEl);
+
+            this.items.push(item);
+
+            if(!item.isSelected){
+                return;
+            }
+
+            //defer this because we hook into the mutation
+            //event in order to populate Selleckt, and that
+            //event fires asynchronously
+            _.defer(function(){
+                selectItem(item);
+            });
+        },
+
+        removeItem: function(item){
+            if(item.isSelected){
+                this.selectedItem = undefined;
+            }
+
+            console.log('remove item', arguments);
+        },
+
         render: function(){
             var templateData = this.getTemplateData(),
                 $originalSelectEl = this.$originalSelectEl,
@@ -678,6 +771,8 @@
             this.$overflowHiddenParent = getOverflowHiddenParent($sellecktEl);
 
             this.bindEvents();
+
+            this._observeMutations($originalSelectEl[0]);
 
             this.hideSelectionFromChoices();
         },

--- a/test/index.html
+++ b/test/index.html
@@ -8,15 +8,16 @@
 
     <link rel="stylesheet" href="lib/mocha/mocha.css" />
 
-    <script src="lib/mocha/mocha.js"></script>
-    <script src="lib/expectations.js"></script>
-    <script src="lib/sinon-1.1.0.js"></script>
-    <script src="/testem.js"></script>
-
     <!--[if IE 8 ]>
     <script src="../shims/object-create-shim.js"></script>
     <script src="../shims/es5-shim.min.js"></script>
     <![endif]-->
+
+    <script src="lib/mocha/mocha.js"></script>
+    <script src="lib/expectations.js"></script>
+    <script src="lib/sinon-1.1.0.js"></script>
+    <script src="../shims/mutationobserver-shim.js"></script>
+    <script src="/testem.js"></script>
 
     <style>
         body{

--- a/test/lib/mustache.js
+++ b/test/lib/mustache.js
@@ -5,49 +5,39 @@
 
 /*global define: false*/
 
-(function (root, factory) {
+(function (global, factory) {
   if (typeof exports === "object" && exports) {
-    module.exports = factory; // CommonJS
+    factory(exports); // CommonJS
   } else if (typeof define === "function" && define.amd) {
-    define(factory); // AMD
+    define(['exports'], factory); // AMD
   } else {
-    root.Mustache = factory; // <script>
+    factory(global.Mustache = {}); // <script>
   }
-}(this, (function () {
+}(this, function (mustache) {
 
-  var exports = {};
+  var Object_toString = Object.prototype.toString;
+  var isArray = Array.isArray || function (object) {
+    return Object_toString.call(object) === '[object Array]';
+  };
 
-  exports.name = "mustache.js";
-  exports.version = "0.7.2";
-  exports.tags = ["{{", "}}"];
+  function isFunction(object) {
+    return typeof object === 'function';
+  }
 
-  exports.Scanner = Scanner;
-  exports.Context = Context;
-  exports.Writer = Writer;
-
-  var whiteRe = /\s*/;
-  var spaceRe = /\s+/;
-  var nonSpaceRe = /\S/;
-  var eqRe = /\s*=/;
-  var curlyRe = /\s*\}/;
-  var tagRe = /#|\^|\/|>|\{|&|=|!/;
+  function escapeRegExp(string) {
+    return string.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
+  }
 
   // Workaround for https://issues.apache.org/jira/browse/COUCHDB-577
   // See https://github.com/janl/mustache.js/issues/189
-  function testRe(re, string) {
-    return RegExp.prototype.test.call(re, string);
+  var RegExp_test = RegExp.prototype.test;
+  function testRegExp(re, string) {
+    return RegExp_test.call(re, string);
   }
 
+  var nonSpaceRe = /\S/;
   function isWhitespace(string) {
-    return !testRe(nonSpaceRe, string);
-  }
-
-  var isArray = Array.isArray || function (obj) {
-    return Object.prototype.toString.call(obj) === "[object Array]";
-  };
-
-  function escapeRe(string) {
-    return string.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
+    return !testRegExp(nonSpaceRe, string);
   }
 
   var entityMap = {
@@ -65,10 +55,224 @@
     });
   }
 
-  // Export the escaping function so that the user may override it.
-  // See https://github.com/janl/mustache.js/issues/244
-  exports.escape = escapeHtml;
+  var whiteRe = /\s*/;
+  var spaceRe = /\s+/;
+  var equalsRe = /\s*=/;
+  var curlyRe = /\s*\}/;
+  var tagRe = /#|\^|\/|>|\{|&|=|!/;
 
+  /**
+   * Breaks up the given `template` string into a tree of tokens. If the `tags`
+   * argument is given here it must be an array with two string values: the
+   * opening and closing tags used in the template (e.g. [ "<%", "%>" ]). Of
+   * course, the default is to use mustaches (i.e. mustache.tags).
+   *
+   * A token is an array with at least 4 elements. The first element is the
+   * mustache symbol that was used inside the tag, e.g. "#" or "&". If the tag
+   * did not contain a symbol (i.e. {{myValue}}) this element is "name". For
+   * all text that appears outside a symbol this element is "text".
+   *
+   * The second element of a token is its "value". For mustache tags this is
+   * whatever else was inside the tag besides the opening symbol. For text tokens
+   * this is the text itself.
+   *
+   * The third and fourth elements of the token are the start and end indices,
+   * respectively, of the token in the original template.
+   *
+   * Tokens that are the root node of a subtree contain two more elements: 1) an
+   * array of tokens in the subtree and 2) the index in the original template at
+   * which the closing tag for that section begins.
+   */
+  function parseTemplate(template, tags) {
+    if (!template)
+      return [];
+
+    var sections = [];     // Stack to hold section tokens
+    var tokens = [];       // Buffer to hold the tokens
+    var spaces = [];       // Indices of whitespace tokens on the current line
+    var hasTag = false;    // Is there a {{tag}} on the current line?
+    var nonSpace = false;  // Is there a non-space char on the current line?
+
+    // Strips all whitespace tokens array for the current line
+    // if there was a {{#tag}} on it and otherwise only space.
+    function stripSpace() {
+      if (hasTag && !nonSpace) {
+        while (spaces.length)
+          delete tokens[spaces.pop()];
+      } else {
+        spaces = [];
+      }
+
+      hasTag = false;
+      nonSpace = false;
+    }
+
+    var openingTagRe, closingTagRe, closingCurlyRe;
+    function compileTags(tags) {
+      if (typeof tags === 'string')
+        tags = tags.split(spaceRe, 2);
+
+      if (!isArray(tags) || tags.length !== 2)
+        throw new Error('Invalid tags: ' + tags);
+
+      openingTagRe = new RegExp(escapeRegExp(tags[0]) + '\\s*');
+      closingTagRe = new RegExp('\\s*' + escapeRegExp(tags[1]));
+      closingCurlyRe = new RegExp('\\s*' + escapeRegExp('}' + tags[1]));
+    }
+
+    compileTags(tags || mustache.tags);
+
+    var scanner = new Scanner(template);
+
+    var start, type, value, chr, token, openSection;
+    while (!scanner.eos()) {
+      start = scanner.pos;
+
+      // Match any text between tags.
+      value = scanner.scanUntil(openingTagRe);
+
+      if (value) {
+        for (var i = 0, valueLength = value.length; i < valueLength; ++i) {
+          chr = value.charAt(i);
+
+          if (isWhitespace(chr)) {
+            spaces.push(tokens.length);
+          } else {
+            nonSpace = true;
+          }
+
+          tokens.push([ 'text', chr, start, start + 1 ]);
+          start += 1;
+
+          // Check for whitespace on the current line.
+          if (chr === '\n')
+            stripSpace();
+        }
+      }
+
+      // Match the opening tag.
+      if (!scanner.scan(openingTagRe))
+        break;
+
+      hasTag = true;
+
+      // Get the tag type.
+      type = scanner.scan(tagRe) || 'name';
+      scanner.scan(whiteRe);
+
+      // Get the tag value.
+      if (type === '=') {
+        value = scanner.scanUntil(equalsRe);
+        scanner.scan(equalsRe);
+        scanner.scanUntil(closingTagRe);
+      } else if (type === '{') {
+        value = scanner.scanUntil(closingCurlyRe);
+        scanner.scan(curlyRe);
+        scanner.scanUntil(closingTagRe);
+        type = '&';
+      } else {
+        value = scanner.scanUntil(closingTagRe);
+      }
+
+      // Match the closing tag.
+      if (!scanner.scan(closingTagRe))
+        throw new Error('Unclosed tag at ' + scanner.pos);
+
+      token = [ type, value, start, scanner.pos ];
+      tokens.push(token);
+
+      if (type === '#' || type === '^') {
+        sections.push(token);
+      } else if (type === '/') {
+        // Check section nesting.
+        openSection = sections.pop();
+
+        if (!openSection)
+          throw new Error('Unopened section "' + value + '" at ' + start);
+
+        if (openSection[1] !== value)
+          throw new Error('Unclosed section "' + openSection[1] + '" at ' + start);
+      } else if (type === 'name' || type === '{' || type === '&') {
+        nonSpace = true;
+      } else if (type === '=') {
+        // Set the tags for the next time around.
+        compileTags(value);
+      }
+    }
+
+    // Make sure there are no open sections when we're done.
+    openSection = sections.pop();
+
+    if (openSection)
+      throw new Error('Unclosed section "' + openSection[1] + '" at ' + scanner.pos);
+
+    return nestTokens(squashTokens(tokens));
+  }
+
+  /**
+   * Combines the values of consecutive text tokens in the given `tokens` array
+   * to a single token.
+   */
+  function squashTokens(tokens) {
+    var squashedTokens = [];
+
+    var token, lastToken;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+      token = tokens[i];
+
+      if (token) {
+        if (token[0] === 'text' && lastToken && lastToken[0] === 'text') {
+          lastToken[1] += token[1];
+          lastToken[3] = token[3];
+        } else {
+          squashedTokens.push(token);
+          lastToken = token;
+        }
+      }
+    }
+
+    return squashedTokens;
+  }
+
+  /**
+   * Forms the given array of `tokens` into a nested tree structure where
+   * tokens that represent a section have two additional items: 1) an array of
+   * all tokens that appear in that section and 2) the index in the original
+   * template that represents the end of that section.
+   */
+  function nestTokens(tokens) {
+    var nestedTokens = [];
+    var collector = nestedTokens;
+    var sections = [];
+
+    var token, section;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+      token = tokens[i];
+
+      switch (token[0]) {
+      case '#':
+      case '^':
+        collector.push(token);
+        sections.push(token);
+        collector = token[4] = [];
+        break;
+      case '/':
+        section = sections.pop();
+        section[5] = token[2];
+        collector = sections.length > 0 ? sections[sections.length - 1][4] : nestedTokens;
+        break;
+      default:
+        collector.push(token);
+      }
+    }
+
+    return nestedTokens;
+  }
+
+  /**
+   * A simple string scanner that is used by the template parser to find
+   * tokens in template strings.
+   */
   function Scanner(string) {
     this.string = string;
     this.tail = string;
@@ -89,13 +293,15 @@
   Scanner.prototype.scan = function (re) {
     var match = this.tail.match(re);
 
-    if (match && match.index === 0) {
-      this.tail = this.tail.substring(match[0].length);
-      this.pos += match[0].length;
-      return match[0];
-    }
+    if (!match || match.index !== 0)
+      return '';
 
-    return "";
+    var string = match[0];
+
+    this.tail = this.tail.substring(string.length);
+    this.pos += string.length;
+
+    return string;
   };
 
   /**
@@ -103,508 +309,270 @@
    * the skipped string, which is the entire tail if no match can be made.
    */
   Scanner.prototype.scanUntil = function (re) {
-    var match, pos = this.tail.search(re);
+    var index = this.tail.search(re), match;
 
-    switch (pos) {
+    switch (index) {
     case -1:
       match = this.tail;
-      this.pos += this.tail.length;
       this.tail = "";
       break;
     case 0:
       match = "";
       break;
     default:
-      match = this.tail.substring(0, pos);
-      this.tail = this.tail.substring(pos);
-      this.pos += pos;
+      match = this.tail.substring(0, index);
+      this.tail = this.tail.substring(index);
     }
+
+    this.pos += match.length;
 
     return match;
   };
 
-  function Context(view, parent) {
-    this.view = view;
-    this.parent = parent;
-    this.clearCache();
+  /**
+   * Represents a rendering context by wrapping a view object and
+   * maintaining a reference to the parent context.
+   */
+  function Context(view, parentContext) {
+    this.view = view == null ? {} : view;
+    this.cache = { '.': this.view };
+    this.parent = parentContext;
   }
 
-  Context.make = function (view) {
-    return (view instanceof Context) ? view : new Context(view);
-  };
-
-  Context.prototype.clearCache = function () {
-    this._cache = {};
-  };
-
+  /**
+   * Creates a new context using the given view with this context
+   * as the parent.
+   */
   Context.prototype.push = function (view) {
     return new Context(view, this);
   };
 
+  /**
+   * Returns the value of the given name in this context, traversing
+   * up the context hierarchy if the value is absent in this context's view.
+   */
   Context.prototype.lookup = function (name) {
-    var value = this._cache[name];
+    var cache = this.cache;
 
-    if (!value) {
-      if (name === ".") {
-        value = this.view;
-      } else {
-        var context = this;
+    var value;
+    if (name in cache) {
+      value = cache[name];
+    } else {
+      var context = this, names, index;
 
-        while (context) {
-          if (name.indexOf(".") > 0) {
-            var names = name.split("."), i = 0;
+      while (context) {
+        if (name.indexOf('.') > 0) {
+          value = context.view;
+          names = name.split('.');
+          index = 0;
 
-            value = context.view;
-
-            while (value && i < names.length) {
-              value = value[names[i++]];
-            }
-          } else {
-            value = context.view[name];
-          }
-
-          if (value != null) {
-            break;
-          }
-
-          context = context.parent;
+          while (value != null && index < names.length)
+            value = value[names[index++]];
+        } else if (typeof context.view == 'object') {
+          value = context.view[name];
         }
+
+        if (value != null)
+          break;
+
+        context = context.parent;
       }
 
-      this._cache[name] = value;
+      cache[name] = value;
     }
 
-    if (typeof value === "function") {
+    if (isFunction(value))
       value = value.call(this.view);
-    }
 
     return value;
   };
 
+  /**
+   * A Writer knows how to take a stream of tokens and render them to a
+   * string, given a context. It also maintains a cache of templates to
+   * avoid the need to parse the same template twice.
+   */
   function Writer() {
-    this.clearCache();
+    this.cache = {};
   }
 
+  /**
+   * Clears all cached templates in this writer.
+   */
   Writer.prototype.clearCache = function () {
-    this._cache = {};
-    this._partialCache = {};
+    this.cache = {};
   };
 
-  Writer.prototype.compile = function (template, tags) {
-    var fn = this._cache[template];
+  /**
+   * Parses and caches the given `template` and returns the array of tokens
+   * that is generated from the parse.
+   */
+  Writer.prototype.parse = function (template, tags) {
+    var cache = this.cache;
+    var tokens = cache[template];
 
-    if (!fn) {
-      var tokens = exports.parse(template, tags);
-      fn = this._cache[template] = this.compileTokens(tokens, template);
-    }
+    if (tokens == null)
+      tokens = cache[template] = parseTemplate(template, tags);
 
-    return fn;
+    return tokens;
   };
 
-  Writer.prototype.compilePartial = function (name, template, tags) {
-    var fn = this.compile(template, tags);
-    this._partialCache[name] = fn;
-    return fn;
-  };
-
-  Writer.prototype.compileTokens = function (tokens, template) {
-    var fn = compileTokens(tokens);
-    var self = this;
-
-    return function (view, partials) {
-      if (partials) {
-        if (typeof partials === "function") {
-          self._loadPartial = partials;
-        } else {
-          for (var name in partials) {
-            self.compilePartial(name, partials[name]);
-          }
-        }
-      }
-
-      return fn(self, Context.make(view), template);
-    };
-  };
-
+  /**
+   * High-level method that is used to render the given `template` with
+   * the given `view`.
+   *
+   * The optional `partials` argument may be an object that contains the
+   * names and templates of partials that are used in the template. It may
+   * also be a function that is used to load partial templates on the fly
+   * that takes a single argument: the name of the partial.
+   */
   Writer.prototype.render = function (template, view, partials) {
-    return this.compile(template)(view, partials);
-  };
-
-  Writer.prototype._section = function (name, context, text, callback) {
-    var value = context.lookup(name);
-
-    switch (typeof value) {
-    case "object":
-      if (isArray(value)) {
-        var buffer = "";
-
-        for (var i = 0, len = value.length; i < len; ++i) {
-          buffer += callback(this, context.push(value[i]));
-        }
-
-        return buffer;
-      }
-
-      return value ? callback(this, context.push(value)) : "";
-    case "function":
-      var self = this;
-      var scopedRender = function (template) {
-        return self.render(template, context);
-      };
-
-      var result = value.call(context.view, text, scopedRender);
-      return result != null ? result : "";
-    default:
-      if (value) {
-        return callback(this, context);
-      }
-    }
-
-    return "";
-  };
-
-  Writer.prototype._inverted = function (name, context, callback) {
-    var value = context.lookup(name);
-
-    // Use JavaScript's definition of falsy. Include empty arrays.
-    // See https://github.com/janl/mustache.js/issues/186
-    if (!value || (isArray(value) && value.length === 0)) {
-      return callback(this, context);
-    }
-
-    return "";
-  };
-
-  Writer.prototype._partial = function (name, context) {
-    if (!(name in this._partialCache) && this._loadPartial) {
-      this.compilePartial(name, this._loadPartial(name));
-    }
-
-    var fn = this._partialCache[name];
-
-    return fn ? fn(context) : "";
-  };
-
-  Writer.prototype._name = function (name, context) {
-    var value = context.lookup(name);
-
-    if (typeof value === "function") {
-      value = value.call(context.view);
-    }
-
-    return (value == null) ? "" : String(value);
-  };
-
-  Writer.prototype._escaped = function (name, context) {
-    return exports.escape(this._name(name, context));
+    var tokens = this.parse(template);
+    var context = (view instanceof Context) ? view : new Context(view);
+    return this.renderTokens(tokens, context, partials, template);
   };
 
   /**
-   * Low-level function that compiles the given `tokens` into a function
-   * that accepts three arguments: a Writer, a Context, and the template.
+   * Low-level method that renders the given array of `tokens` using
+   * the given `context` and `partials`.
+   *
+   * Note: The `originalTemplate` is only ever used to extract the portion
+   * of the original template that was contained in a higher-order section.
+   * If the template doesn't use higher-order sections, this argument may
+   * be omitted.
    */
-  function compileTokens(tokens) {
-    var subRenders = {};
+  Writer.prototype.renderTokens = function (tokens, context, partials, originalTemplate) {
+    var buffer = '';
 
-    function subRender(i, tokens, template) {
-      if (!subRenders[i]) {
-        var fn = compileTokens(tokens);
-        subRenders[i] = function (writer, context) {
-          return fn(writer, context, template);
-        };
-      }
-
-      return subRenders[i];
+    // This function is used to render an arbitrary template
+    // in the current context by higher-order sections.
+    var self = this;
+    function subRender(template) {
+      return self.render(template, context, partials);
     }
 
-    return function (writer, context, template) {
-      var buffer = "";
-      var token, sectionText;
-
-      for (var i = 0, len = tokens.length; i < len; ++i) {
-        token = tokens[i];
-
-        switch (token[0]) {
-        case "#":
-          sectionText = template.slice(token[3], token[5]);
-          buffer += writer._section(token[1], context, sectionText, subRender(i, token[4], template));
-          break;
-        case "^":
-          buffer += writer._inverted(token[1], context, subRender(i, token[4], template));
-          break;
-        case ">":
-          buffer += writer._partial(token[1], context);
-          break;
-        case "&":
-          buffer += writer._name(token[1], context);
-          break;
-        case "name":
-          buffer += writer._escaped(token[1], context);
-          break;
-        case "text":
-          buffer += token[1];
-          break;
-        }
-      }
-
-      return buffer;
-    };
-  }
-
-  /**
-   * Forms the given array of `tokens` into a nested tree structure where
-   * tokens that represent a section have two additional items: 1) an array of
-   * all tokens that appear in that section and 2) the index in the original
-   * template that represents the end of that section.
-   */
-  function nestTokens(tokens) {
-    var tree = [];
-    var collector = tree;
-    var sections = [];
-
-    var token;
-    for (var i = 0, len = tokens.length; i < len; ++i) {
+    var token, value;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
       token = tokens[i];
+
       switch (token[0]) {
       case '#':
+        value = context.lookup(token[1]);
+
+        if (!value)
+          continue;
+
+        if (isArray(value)) {
+          for (var j = 0, valueLength = value.length; j < valueLength; ++j) {
+            buffer += this.renderTokens(token[4], context.push(value[j]), partials, originalTemplate);
+          }
+        } else if (typeof value === 'object' || typeof value === 'string') {
+          buffer += this.renderTokens(token[4], context.push(value), partials, originalTemplate);
+        } else if (isFunction(value)) {
+          if (typeof originalTemplate !== 'string')
+            throw new Error('Cannot use higher-order sections without the original template');
+
+          // Extract the portion of the original template that the section contains.
+          value = value.call(context.view, originalTemplate.slice(token[3], token[5]), subRender);
+
+          if (value != null)
+            buffer += value;
+        } else {
+          buffer += this.renderTokens(token[4], context, partials, originalTemplate);
+        }
+
+        break;
       case '^':
-        sections.push(token);
-        collector.push(token);
-        collector = token[4] = [];
+        value = context.lookup(token[1]);
+
+        // Use JavaScript's definition of falsy. Include empty arrays.
+        // See https://github.com/janl/mustache.js/issues/186
+        if (!value || (isArray(value) && value.length === 0))
+          buffer += this.renderTokens(token[4], context, partials, originalTemplate);
+
         break;
-      case '/':
-        var section = sections.pop();
-        section[5] = token[2];
-        collector = sections.length > 0 ? sections[sections.length - 1][4] : tree;
+      case '>':
+        if (!partials)
+          continue;
+
+        value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
+
+        if (value != null)
+          buffer += this.renderTokens(this.parse(value), context, partials, value);
+
         break;
-      default:
-        collector.push(token);
-      }
-    }
+      case '&':
+        value = context.lookup(token[1]);
 
-    return tree;
-  }
+        if (value != null)
+          buffer += value;
 
-  /**
-   * Combines the values of consecutive text tokens in the given `tokens` array
-   * to a single token.
-   */
-  function squashTokens(tokens) {
-    var squashedTokens = [];
+        break;
+      case 'name':
+        value = context.lookup(token[1]);
 
-    var token, lastToken;
-    for (var i = 0, len = tokens.length; i < len; ++i) {
-      token = tokens[i];
-      if (token[0] === 'text' && lastToken && lastToken[0] === 'text') {
-        lastToken[1] += token[1];
-        lastToken[3] = token[3];
-      } else {
-        lastToken = token;
-        squashedTokens.push(token);
-      }
-    }
+        if (value != null)
+          buffer += mustache.escape(value);
 
-    return squashedTokens;
-  }
-
-  function escapeTags(tags) {
-    return [
-      new RegExp(escapeRe(tags[0]) + "\\s*"),
-      new RegExp("\\s*" + escapeRe(tags[1]))
-    ];
-  }
-
-  /**
-   * Breaks up the given `template` string into a tree of token objects. If
-   * `tags` is given here it must be an array with two string values: the
-   * opening and closing tags used in the template (e.g. ["<%", "%>"]). Of
-   * course, the default is to use mustaches (i.e. Mustache.tags).
-   */
-  exports.parse = function (template, tags) {
-    template = template || '';
-    tags = tags || exports.tags;
-
-    if (typeof tags === 'string') tags = tags.split(spaceRe);
-    if (tags.length !== 2) {
-      throw new Error('Invalid tags: ' + tags.join(', '));
-    }
-
-    var tagRes = escapeTags(tags);
-    var scanner = new Scanner(template);
-
-    var sections = [];     // Stack to hold section tokens
-    var tokens = [];       // Buffer to hold the tokens
-    var spaces = [];       // Indices of whitespace tokens on the current line
-    var hasTag = false;    // Is there a {{tag}} on the current line?
-    var nonSpace = false;  // Is there a non-space char on the current line?
-
-    // Strips all whitespace tokens array for the current line
-    // if there was a {{#tag}} on it and otherwise only space.
-    function stripSpace() {
-      if (hasTag && !nonSpace) {
-        while (spaces.length) {
-          tokens.splice(spaces.pop(), 1);
-        }
-      } else {
-        spaces = [];
-      }
-
-      hasTag = false;
-      nonSpace = false;
-    }
-
-    var start, type, value, chr;
-    while (!scanner.eos()) {
-      start = scanner.pos;
-      value = scanner.scanUntil(tagRes[0]);
-
-      if (value) {
-        for (var i = 0, len = value.length; i < len; ++i) {
-          chr = value.charAt(i);
-
-          if (isWhitespace(chr)) {
-            spaces.push(tokens.length);
-          } else {
-            nonSpace = true;
-          }
-
-          tokens.push(["text", chr, start, start + 1]);
-          start += 1;
-
-          if (chr === "\n") {
-            stripSpace(); // Check for whitespace on the current line.
-          }
-        }
-      }
-
-      start = scanner.pos;
-
-      // Match the opening tag.
-      if (!scanner.scan(tagRes[0])) {
+        break;
+      case 'text':
+        buffer += token[1];
         break;
       }
-
-      hasTag = true;
-      type = scanner.scan(tagRe) || "name";
-
-      // Skip any whitespace between tag and value.
-      scanner.scan(whiteRe);
-
-      // Extract the tag value.
-      if (type === "=") {
-        value = scanner.scanUntil(eqRe);
-        scanner.scan(eqRe);
-        scanner.scanUntil(tagRes[1]);
-      } else if (type === "{") {
-        var closeRe = new RegExp("\\s*" + escapeRe("}" + tags[1]));
-        value = scanner.scanUntil(closeRe);
-        scanner.scan(curlyRe);
-        scanner.scanUntil(tagRes[1]);
-        type = "&";
-      } else {
-        value = scanner.scanUntil(tagRes[1]);
-      }
-
-      // Match the closing tag.
-      if (!scanner.scan(tagRes[1])) {
-        throw new Error('Unclosed tag at ' + scanner.pos);
-      }
-
-      // Check section nesting.
-      if (type === '/') {
-        if (sections.length === 0) {
-          throw new Error('Unopened section "' + value + '" at ' + start);
-        }
-
-        var section = sections.pop();
-
-        if (section[1] !== value) {
-          throw new Error('Unclosed section "' + section[1] + '" at ' + start);
-        }
-      }
-
-      var token = [type, value, start, scanner.pos];
-      tokens.push(token);
-
-      if (type === '#' || type === '^') {
-        sections.push(token);
-      } else if (type === "name" || type === "{" || type === "&") {
-        nonSpace = true;
-      } else if (type === "=") {
-        // Set the tags for the next time around.
-        tags = value.split(spaceRe);
-
-        if (tags.length !== 2) {
-          throw new Error('Invalid tags at ' + start + ': ' + tags.join(', '));
-        }
-
-        tagRes = escapeTags(tags);
-      }
     }
 
-    // Make sure there are no open sections when we're done.
-    var section = sections.pop();
-    if (section) {
-      throw new Error('Unclosed section "' + section[1] + '" at ' + scanner.pos);
-    }
-
-    return nestTokens(squashTokens(tokens));
+    return buffer;
   };
 
-  // The high-level clearCache, compile, compilePartial, and render functions
-  // use this default writer.
-  var _writer = new Writer();
+  mustache.name = "mustache.js";
+  mustache.version = "1.0.0";
+  mustache.tags = [ "{{", "}}" ];
+
+  // All high-level mustache.* functions use this writer.
+  var defaultWriter = new Writer();
 
   /**
-   * Clears all cached templates and partials in the default writer.
+   * Clears all cached templates in the default writer.
    */
-  exports.clearCache = function () {
-    return _writer.clearCache();
+  mustache.clearCache = function () {
+    return defaultWriter.clearCache();
   };
 
   /**
-   * Compiles the given `template` to a reusable function using the default
-   * writer.
+   * Parses and caches the given template in the default writer and returns the
+   * array of tokens it contains. Doing this ahead of time avoids the need to
+   * parse templates on the fly as they are rendered.
    */
-  exports.compile = function (template, tags) {
-    return _writer.compile(template, tags);
-  };
-
-  /**
-   * Compiles the partial with the given `name` and `template` to a reusable
-   * function using the default writer.
-   */
-  exports.compilePartial = function (name, template, tags) {
-    return _writer.compilePartial(name, template, tags);
-  };
-
-  /**
-   * Compiles the given array of tokens (the output of a parse) to a reusable
-   * function using the default writer.
-   */
-  exports.compileTokens = function (tokens, template) {
-    return _writer.compileTokens(tokens, template);
+  mustache.parse = function (template, tags) {
+    return defaultWriter.parse(template, tags);
   };
 
   /**
    * Renders the `template` with the given `view` and `partials` using the
    * default writer.
    */
-  exports.render = function (template, view, partials) {
-    return _writer.render(template, view, partials);
+  mustache.render = function (template, view, partials) {
+    return defaultWriter.render(template, view, partials);
   };
 
   // This is here for backwards compatibility with 0.4.x.
-  exports.to_html = function (template, view, partials, send) {
-    var result = exports.render(template, view, partials);
+  mustache.to_html = function (template, view, partials, send) {
+    var result = mustache.render(template, view, partials);
 
-    if (typeof send === "function") {
+    if (isFunction(send)) {
       send(result);
     } else {
       return result;
     }
   };
 
-  return exports;
+  // Export the escaping function so that the user may override it.
+  // See https://github.com/janl/mustache.js/issues/244
+  mustache.escape = escapeHtml;
 
-}())));
+  // Export these mainly for testing, but also for advanced usage.
+  mustache.Scanner = Scanner;
+  mustache.Context = Context;
+  mustache.Writer = Writer;
+
+}));

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -436,6 +436,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
         describe('Adding items', function(){
             var item;
+            var waitTime = 100;
 
             beforeEach(function(){
                 item = {
@@ -448,6 +449,11 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 });
 
                 selleckt.render();
+            });
+
+            afterEach(function(){
+                selleckt.destroy();
+                selleckt = undefined;
             });
 
             describe('using addItem to add a single item', function(){
@@ -487,7 +493,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     setTimeout(function(){
                         expect($sellecktEl.find(itemClass).length).toEqual(4);
                         done();
-                    }, 0);
+                    }, waitTime);
                 });
 
                 it('selects the new item when it is clicked', function(done){
@@ -507,7 +513,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new');
 
                         done();
-                    }, 0);
+                    }, waitTime);
                 });
 
                 describe('and the new item has selected:true', function(){
@@ -529,7 +535,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                             expect(newSelection.length).toEqual(1);
                             expect(newSelection.val()).toEqual('new value');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('selects the new item in Selleckt', function(done){
@@ -542,7 +548,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('hides the new item from the Selleckt list', function(done){
@@ -553,7 +559,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect(selleckt.$items.find('.item[data-value="new value"]').css('display')).toEqual('none');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('adds the previously selected item back to the Selleckt list', function(done){
@@ -564,7 +570,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('list-item');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('deselects the previously selected item in the Selleckt', function(done){
@@ -577,7 +583,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                             expect(selleckt.selectedItem.value).toEqual('new value');
                             expect(selleckt.selectedItem.label).toEqual('new');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
                 });
             });
@@ -642,7 +648,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     setTimeout(function(){
                         expect($sellecktEl.find(itemClass).length).toEqual(6);
                         done();
-                    }, 0);
+                    }, waitTime);
                 });
 
                 describe('and a new item has selected:true', function(){
@@ -664,7 +670,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                             expect(newSelection.length).toEqual(1);
                             expect(newSelection.val()).toEqual('new value 1');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('selects the new item in Selleckt', function(done){
@@ -677,7 +683,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new 1');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('hides the new item from the Selleckt list', function(done){
@@ -688,7 +694,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect(selleckt.$items.find('.item[data-value="new value 1"]').css('display')).toEqual('none');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('adds the previously selected item back to the Selleckt list', function(done){
@@ -699,7 +705,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         setTimeout(function(){
                             expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('list-item');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
 
                     it('deselects the previously selected item in the Selleckt', function(done){
@@ -712,14 +718,113 @@ define(['lib/selleckt', 'lib/mustache.js'],
                             expect(selleckt.selectedItem.value).toEqual('new value 1');
                             expect(selleckt.selectedItem.label).toEqual('new 1');
                             done();
-                        }, 0);
+                        }, waitTime);
                     });
                 });
             });
         });
 
         describe('Removing items', function(){
-            it('observes removals from the original select');
+            var removeItemValue;
+            var waitTime = MutationObserver._period ? MutationObserver._period * 2 : 1;
+
+            beforeEach(function(){
+                selleckt = Selleckt.create({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+            });
+
+            afterEach(function(){
+                selleckt.destroy();
+                selleckt = undefined;
+            });
+
+            describe('and the removed item is not selected', function(){
+                beforeEach(function(){
+                    removeItemValue = selleckt.items[2].value;
+                });
+
+                it('removes the item from this.items', function(){
+                    expect(selleckt.items.length).toEqual(3);
+                    expect(selleckt.findItem(removeItemValue)).toBeDefined();
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.items.length).toEqual(2);
+                    expect(selleckt.findItem(removeItemValue)).toBeUndefined();
+                });
+
+                it('removes the option with the corresponding value from the original select', function(){
+                    var $originalSelectEl = selleckt.$originalSelectEl;
+
+                    expect($originalSelectEl.children().length).toEqual(3);
+                    expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(1);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect($originalSelectEl.children().length).toEqual(2);
+                    expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(0);
+                });
+
+                it('removes the corresponding item from the Selleckt element itself', function(done){
+                    var $sellecktEl = selleckt.$sellecktEl;
+                    var itemClass = '.' + selleckt.itemClass;
+
+                    expect($sellecktEl.find(itemClass).length).toEqual(3);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    //because of the dom event
+                    setTimeout(function(){
+                        expect(selleckt.$originalSelectEl.children().length).toEqual(2);
+                        expect($sellecktEl.find(itemClass).length).toEqual(2);
+
+                        done();
+                    }, waitTime);
+                });
+            });
+
+            describe('and the removed item is selected', function(){
+                beforeEach(function(){
+                    removeItemValue = selleckt.selectedItem.value;
+                });
+
+                it('removes the corresponding item from the Selleckt element itself', function(done){
+                    var $sellecktEl = selleckt.$sellecktEl;
+                    var itemClass = '.' + selleckt.itemClass;
+
+                    expect($sellecktEl.find(itemClass).length).toEqual(3);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    //because of the dom event
+                    setTimeout(function(){
+                        expect(selleckt.$originalSelectEl.children().length).toEqual(2);
+                        expect($sellecktEl.find(itemClass).length).toEqual(2);
+
+                        done();
+                    }, waitTime);
+                });
+
+                it('sets this.selectedItem to undefined if it has the value of the item being removed', function(){
+                    expect(selleckt.selectedItem).toBeDefined();
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.selectedItem).toBeUndefined();
+                });
+
+                it('sets the placeholder text back', function(){
+                    expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.selectedItem.label);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.placeholderText);
+                });
+            });
+
         });
 
         describe('Events', function(){

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -1543,7 +1543,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 '</div>',
             selectionTemplate =
                 '<li class="mySelectionItem custom-item" data-value="{{value}}">' +
-                    '{{text}}<i class="icon-remove remove"></i>' +
+                    '{{text}}<i class="icon-remove unselect"></i>' +
                 '</li>';
 
         beforeEach(function(){
@@ -1575,7 +1575,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         alternatePlaceholder: 'click me again!',
                         itemsClass: 'items',
                         itemClass: 'item',
-                        removeItemClass: 'removeItem',
+                        unselectItemClass: 'unselectItem',
                         selectedClass: 'isSelected',
                         highlightClass: 'isHighlighted',
                         showEmptyList: true
@@ -1597,8 +1597,8 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 it('stores options.alternatePlaceholder as this.alternatePlaceholder',function(){
                     expect(multiSelleckt.alternatePlaceholder).toEqual('click me again!');
                 });
-                it('stores options.removeItemClass as this.removeItemClass',function(){
-                    expect(multiSelleckt.removeItemClass).toEqual('removeItem');
+                it('stores options.unselectItemClass as this.unselectItemClass',function(){
+                    expect(multiSelleckt.unselectItemClass).toEqual('unselectItem');
                 });
                 it('stores options.selectedClassName as this.selectedClass',function(){
                     expect(multiSelleckt.selectedClass).toEqual('isSelected');
@@ -1625,8 +1625,8 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 it('defaults this.selectionItemClass to "selectionItem"',function(){
                     expect(multiSelleckt.selectionItemClass).toEqual('selectionItem');
                 });
-                it('defaults this.removeItemClass to "remove"',function(){
-                    expect(multiSelleckt.removeItemClass).toEqual('remove');
+                it('defaults this.unselectItemClass to "unselect"',function(){
+                    expect(multiSelleckt.unselectItemClass).toEqual('unselect');
                 });
                 it('defaults this.placeholderText to "Please select..."',function(){
                     expect(multiSelleckt.placeholderText).toEqual('Please select...');
@@ -1681,13 +1681,13 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     multiple: true,
                     $selectEl: $el,
                     selectionItemClass: 'selected-item',
-                    removeItemClass: 'remove-selected'
+                    unselectItemClass: 'unselect'
                 });
 
                 itemData = multiSelleckt.getItemTemplateData(multiSelleckt.items[0]);
 
                 expect(itemData.selectionItemClass).toEqual('selected-item');
-                expect(itemData.removeItemClass).toEqual('remove-selected');
+                expect(itemData.unselectItemClass).toEqual('unselect');
             });
 
             it('includes option data attributes as property of item template data', function(){
@@ -1852,14 +1852,14 @@ define(['lib/selleckt', 'lib/mustache.js'],
             });
 
             describe('item deselection', function(){
-                it('removes an item when the "remove" link is clicked', function(){
+                it('removes an item when the "unselect" link is clicked', function(){
                     multiSelleckt.render();
 
                     expect(multiSelleckt.getSelection().length).toEqual(2);
 
                     expect(multiSelleckt.$sellecktEl.find('.selectionItem').length).toEqual(2);
 
-                    multiSelleckt.$sellecktEl.find('.selectionItem .remove').first().trigger('click');
+                    multiSelleckt.$sellecktEl.find('.selectionItem .unselect').first().trigger('click');
 
                     expect(multiSelleckt.$sellecktEl.find('.selectionItem').length).toEqual(1);
                 });
@@ -1871,7 +1871,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(multiSelleckt.getSelection().length).toEqual(3);
                     expect(multiSelleckt.$sellecktEl.hasClass('disabled')).toEqual(true);
 
-                    multiSelleckt.$sellecktEl.find('.selectionItem .remove').first().trigger('click');
+                    multiSelleckt.$sellecktEl.find('.selectionItem .unselect').first().trigger('click');
 
                     expect(multiSelleckt.getSelection().length).toEqual(2);
                     expect(multiSelleckt.$sellecktEl.hasClass('disabled')).toEqual(false);
@@ -1887,7 +1887,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     multiSelleckt.selectItem(multiSelleckt.items[2]);
                     expect(multiSelleckt.$originalSelectEl.val()).toEqual([multiSelleckt.items[1].value, multiSelleckt.items[2].value]);
 
-                    multiSelleckt.removeItem(multiSelleckt.items[2]);
+                    multiSelleckt.unselectItem(multiSelleckt.items[2]);
 
                     expect(multiSelleckt.$originalSelectEl.val()).toEqual([multiSelleckt.items[1].value]);
                 });
@@ -1899,9 +1899,9 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectedTextClass).text())
                         .toEqual(multiSelleckt.alternatePlaceholder);
 
-                    multiSelleckt.removeItem(multiSelleckt.items[0]);
-                    multiSelleckt.removeItem(multiSelleckt.items[1]);
-                    multiSelleckt.removeItem(multiSelleckt.items[2]);
+                    multiSelleckt.unselectItem(multiSelleckt.items[0]);
+                    multiSelleckt.unselectItem(multiSelleckt.items[1]);
+                    multiSelleckt.unselectItem(multiSelleckt.items[2]);
 
                     expect(multiSelleckt.selectedItems.length).toEqual(0);
                     expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectedTextClass).text())
@@ -1910,7 +1910,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
             });
         });
 
-        describe('removing items', function(){
+        describe('unselecting items', function(){
             var $clickTarget;
 
             beforeEach(function(){
@@ -1931,9 +1931,9 @@ define(['lib/selleckt', 'lib/mustache.js'],
                     data: {}
                 }]);
 
-                $clickTarget = multiSelleckt.$sellecktEl.find('.'+multiSelleckt.removeItemClass).eq(0);
+                $clickTarget = multiSelleckt.$sellecktEl.find('.'+multiSelleckt.unselectItemClass).eq(0);
             });
-            it('removes the item from the selections when the remove link is clicked', function(){
+            it('removes the item from the selections when the unselectItem link is clicked', function(){
                 var $selections = multiSelleckt.$selections;
 
                 expect($selections.children().length).toEqual(2);
@@ -1992,10 +1992,10 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                 multiSelleckt.$originalSelectEl.off('change', changeHandler);
             });
-            it('triggers an "itemRemoved" event with the removed item', function(){
+            it('triggers an "itemUnselected" event with the removed item', function(){
                 var spy = sinon.spy();
 
-                multiSelleckt.bind('itemRemoved', spy);
+                multiSelleckt.bind('itemUnselected', spy);
                 $clickTarget.trigger('click');
 
                 expect(spy.calledOnce).toEqual(true);

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -1347,6 +1347,14 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                 expect($el.css('display')).toEqual('inline-block');
             });
+
+            it('stops observing mutation events', function(){
+                var stopObservingMutationsSpy = sinon.spy(selleckt, '_stopObservingMutations');
+
+                selleckt.destroy();
+
+                expect(stopObservingMutationsSpy.calledOnce).toEqual(true);
+            });
         });
     });
 

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -434,6 +434,137 @@ define(['lib/selleckt', 'lib/mustache.js'],
             });
         });
 
+        describe('Adding items', function(){
+            var item;
+
+            beforeEach(function(){
+                item = {
+                    label: 'new',
+                    value: 'new value'
+                };
+
+                selleckt = Selleckt.create({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+            });
+
+            it('adds an item to this.items', function(){
+                expect(selleckt.items.length).toEqual(3);
+
+                selleckt.addItem(item);
+
+                expect(selleckt.items.length).toEqual(4);
+                expect(selleckt.items[3]).toEqual(item);
+            });
+
+            it('appends a new option to the original select', function(){
+                var $originalSelectEl = selleckt.$originalSelectEl;
+
+                expect($originalSelectEl.children().length).toEqual(3);
+
+                selleckt.addItem(item);
+
+                expect($originalSelectEl.children().length).toEqual(4);
+
+                var newOption = $originalSelectEl.find('option').eq(3);
+
+                expect(newOption.text()).toEqual('new');
+                expect(newOption.val()).toEqual('new value');
+            });
+
+            it('appends a new item to the Selleckt element itself', function(done){
+                var $sellecktEl = selleckt.$sellecktEl;
+                var itemClass = '.' + selleckt.itemClass;
+
+                expect($sellecktEl.find(itemClass).length).toEqual(3);
+
+                selleckt.addItem(item);
+
+                //because of the dom event
+                setTimeout(function(){
+                    expect($sellecktEl.find(itemClass).length).toEqual(4);
+                    done();
+                }, 0);
+            });
+
+            describe('and the new item has selected:true', function(){
+                var originalSelection;
+
+                beforeEach(function(){
+                    originalSelection = selleckt.$originalSelectEl.find('option:selected');
+                    item.isSelected = true;
+                });
+
+                it('selects the new item in the original select', function(done){
+                    expect(originalSelection.val()).toEqual('1');
+
+                    selleckt.addItem(item);
+
+                    var newSelection = selleckt.$originalSelectEl.find('option:selected');
+
+                    setTimeout(function(){
+                        expect(newSelection.length).toEqual(1);
+                        expect(newSelection.val()).toEqual('new value');
+                        done();
+                    }, 0);
+                });
+
+                it('selects the new item in Selleckt', function(done){
+                    var $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
+
+                    expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('foo');
+
+                    selleckt.addItem(item);
+
+                    setTimeout(function(){
+                        expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new');
+                        done();
+                    }, 0);
+                });
+
+                it('hides the new item from the Selleckt list', function(done){
+                    expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
+
+                    selleckt.addItem(item);
+
+                    setTimeout(function(){
+                        expect(selleckt.$items.find('.item[data-value="new value"]').css('display')).toEqual('none');
+                        done();
+                    }, 0);
+                });
+
+                it('adds the previously selected item back to the Selleckt list', function(done){
+                    expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
+
+                    selleckt.addItem(item);
+
+                    setTimeout(function(){
+                        expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('list-item');
+                        done();
+                    }, 0);
+                });
+
+                it('deselects the previously selected item in the Selleckt', function(done){
+                    expect(selleckt.selectedItem.value).toEqual('1');
+                    expect(selleckt.selectedItem.label).toEqual('foo');
+
+                    selleckt.addItem(item);
+
+                    setTimeout(function(){
+                        expect(selleckt.selectedItem.value).toEqual('new value');
+                        expect(selleckt.selectedItem.label).toEqual('new');
+                        done();
+                    }, 0);
+                });
+            });
+        });
+
+        describe('Removing items', function(){
+            it('observes removals from the original select');
+        });
+
         describe('Events', function(){
             beforeEach(function(){
                 selleckt = Selleckt.create({

--- a/test/selleckt.tests.js
+++ b/test/selleckt.tests.js
@@ -52,12 +52,13 @@ define(['lib/selleckt', 'lib/mustache.js'],
                         '</li>' +
                         '{{/showSearch}}' +
                         '{{#items}}' +
-                        '<li class="item" data-text="{{label}}" data-value="{{value}}">' +
-                            '<span class="itemText">{{label}}</span>' +
-                        '</li>' +
+                            '{{> item}}' +
                         '{{/items}}' +
                     '</ul>' +
-                '</div>';
+                '</div>',
+                itemTemplate = '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+                    '<span class="{{itemTextClass}}">{{label}}</span>' +
+                '</li>';
 
             describe('invalid instantiation', function(){
                 it('pukes if instantiated with an invalid template format', function(){
@@ -90,6 +91,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 beforeEach(function(){
                     selleckt = Selleckt.create({
                         mainTemplate: template,
+                        itemTemplate: itemTemplate,
                         $selectEl : $el,
                         className: 'selleckt',
                         selectedClass: 'selected',
@@ -118,7 +120,11 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 });
 
                 it('stores options.mainTemplate as this.template', function(){
-                    expect(selleckt.mainTemplate({})).toEqual(Mustache.compile(template)({}));
+                    expect(Mustache.render(selleckt.mainTemplate, {})).toEqual(Mustache.render(template, {}));
+                });
+
+                it('stores options.itemTemplate as this.itemTemplate', function(){
+                    expect(Mustache.render(selleckt.itemTemplate, {})).toEqual(Mustache.render(itemTemplate, {}));
                 });
 
                 it('stores options.mainTemplateData as this.mainTemplateData', function(){
@@ -234,23 +240,6 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 it('accepts template strings', function(){
                     selleckt = Selleckt.create({
                         mainTemplate : template,
-                        $selectEl : $el,
-                        className: 'selleckt',
-                        selectedClass: 'selected',
-                        selectedTextClass: 'selectedText',
-                        itemsClass: 'items',
-                        itemClass: 'item',
-                        selectedClassName: 'isSelected',
-                        highlightClassName: 'isHighlighted'
-                    });
-                    selleckt.render();
-                    expect(selleckt.$sellecktEl.find('.items').length).toEqual(1);
-                    expect(selleckt.$sellecktEl.find('.items > .item').length).toEqual(3);
-                });
-
-                it('accepts compiled templates', function(){
-                    selleckt = Selleckt.create({
-                        mainTemplate : Mustache.compile(template),
                         $selectEl : $el,
                         className: 'selleckt',
                         selectedClass: 'selected',
@@ -1298,7 +1287,7 @@ define(['lib/selleckt', 'lib/mustache.js'],
                 });
 
                 it('stores options.selectionTemplate as this.selectionTemplate',function(){
-                    expect(multiSelleckt.selectionTemplate({})).toEqual(Mustache.compile(selectionTemplate)({}));
+                    expect(Mustache.render(multiSelleckt.selectionTemplate, {})).toEqual(Mustache.render(selectionTemplate, {}));
                 });
                 it('stores options.selectionsClass as this.selectionsClass',function(){
                     expect(multiSelleckt.selectionsClass).toEqual('mySelections');
@@ -1368,21 +1357,6 @@ define(['lib/selleckt', 'lib/mustache.js'],
 
                 multiSelleckt.render();
 
-                expect(multiSelleckt.$sellecktEl.find('.mySelectionItem').length).toEqual(2);
-                expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(0).text()).toEqual('foo');
-                expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(1).text()).toEqual('baz');
-            });
-
-            it('accepts compiled templates', function(){
-                multiSelleckt = Selleckt.create({
-                    multiple: true,
-                    $selectEl : $el,
-                    selectionsClass: 'mySelections',
-                    selectionItemClass: 'mySelectionItem',
-                    mainTemplate : Mustache.compile(mainTemplate),
-                    selectionTemplate: Mustache.compile(selectionTemplate)
-                });
-                multiSelleckt.render();
                 expect(multiSelleckt.$sellecktEl.find('.mySelectionItem').length).toEqual(2);
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(0).text()).toEqual('foo');
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(1).text()).toEqual('baz');


### PR DESCRIPTION
@spmason this introduces the ability to dynamically add and remove items to Selleckt.

It uses a Dom Mutation Observer to watch changes to the underlying select element. Those changes can be direct in the dom, or instead via the new 'add/remove' item(s) methods. This should allow for flexibility from the implementor.

I had to change the public api as part of this, as there was a method called `removeItem` in MultiSelleckt that actually 'unselected' an item. This was a naming clash with the new methods.

I've also moved to mustache 0.8 for its better partials support.