### PR TITLE
Selleckt popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,27 @@ The following options can be passed to selleckt:
     </thead>
         <tr>
             <td>mainTemplate</td>
-            <td>string or compiled mustacheJs template function</td>
+            <td>string</td>
+            <td>
+                <a href="#templates">See below for default templates</a>
+            </div>
+            </td>
+            <td>
+            </td>
+        </tr>
+        <tr>
+            <td>itemTemplate</td>
+            <td>string</td>
+            <td>
+                <a href="#templates">See below for default templates</a>
+            </div>
+            </td>
+            <td>
+            </td>
+        </tr>
+        <tr>
+            <td>popupTemplate</td>
+            <td>string</td>
             <td>
                 <a href="#templates">See below for default templates</a>
             </div>
@@ -190,9 +210,16 @@ The following options can be passed to selleckt:
             <td>number</td>
             <td>0</td>
             <td>
-                 If the amount of items is above this number, and enableSearch is true then the search input will render.
+                If the amount of items is above this number, and enableSearch is true then the search input will render.
             </td>
         </tr>
+        <tr>
+            <td>hideSelectedItem</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>
+                set to `true` if you want currently selected items to not show in the `SellecktPopup`
+            </td>
     <tbody>
     </tbody>
 </table>
@@ -276,51 +303,68 @@ For multiselleckts, in addition to the above:
 Templates
 =================
 
-An example basic template:
-````html
-<div class="{{className}}" tabindex=1>
-    <div class="selected">
-        <span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>
-    </div>
-    <ul class="items">
-        {{#showSearch}}
-        <li class="searchContainer">
-            <input class="search"></input>
-        </li>
-        {{/showSearch}}
-        {{#items}}
-        <li class="item" data-text="{{label}}" data-value="{{value}}">
-            <span class="itemText">{{label}}</span>
-        </li>
-        {{/items}}
-    </ul>
-</div>
-````
-An example template for multiselleckt:
-````html
-<div class="{{className}}" tabindex=1>
-    <ul class="{{selectionsClass}}">
-    {{#selections}}
-    {{/selections}}
-    </ul>
-    <div class="selected">
-        <span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>
-    </div>
-    <ul class="items">
-        {{#items}}
-        <li class="item" data-text="{{label}}" data-value="{{value}}">
-            {{label}}
-        </li>
-        {{/items}}
-    </ul>
-</div>
-````
-An example template for a multiselleckt item:
-````html
-<li class="{{selectionItemClass}}" data-value="{{value}}">
-    {{text}}<i class="icon-remove {{unselectItemClass}}"></i>
-</li>
-````
+Selleckt uses mustache templates in order to render. There are 3 separate templates used in SingleSelleckt instances, and 4 in MultiSelleckt instances. The templates are explained in the following table:
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Usage</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>mainTemplate</td>
+            <td>SingleSelleckt and MultiSelleckt</td>
+            <td>
+                <p>
+                This template is the 'trigger' or 'opener' element for the selleckt popup. It's what you see in the DOM instead of the original `select` element.
+                </p>
+                <p>
+                There's defaults for this template in `TEMPLATES.SINGLE` and `TEMPLATES.MULTI`
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>itemTemplate</td>
+            <td>SingleSelleckt and MultiSelleckt</td>
+            <td>
+                <p>
+                This template is used to render a single item in the `SellecktPopup`. It represents an `option` element from the original `select`
+                </p>
+                <p>
+                There's defaults for this template in `TEMPLATES.SINGLE_ITEM` and `TEMPLATES.MULTI_ITEM`
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>popupTemplate</td>
+            <td>SingleSelleckt and MultiSelleckt</td>
+            <td>
+                <p>
+                This template is used to render the `SellecktPopup` - this element is attached to the `body` of the document and positioned absolutely.
+                </p>
+                <p>
+                There's a default for this template in `TEMPLATES.ITEMS_CONTAINER`
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>selectionTemplate</td>
+            <td>MultiSelleckt</td>
+            <td>
+                <p>
+                This template is used to render a single selected item in the MultiSelleckt. The items are attached to the DOM above the replaced `select` element so you can see which items have been selected.
+                </p>
+                <p>
+                There's a default for this template in `TEMPLATES.MULTI_SELECTION`
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
 
 <a name="events"></a>
 Events
@@ -348,9 +392,32 @@ The following events are raised by an instance of selleckt:
             <td>Triggered each time an option is selected by the user. An item is an object representing an option in the selleckt, consisting of value, label and data properties.</td>
         </tr>
         <tr>
+            <td>itemUnselected</td>
+            <td>The item that the user has unselected from a </td>
+            <td>Triggered each time an option is deselected by the user. An item is an object representing an option in the selleckt, consisting of value, label and data properties.</td>
+        </tr>
+        <tr>
             <td>optionsFiltered</td>
             <td>The user's search term</td>
             <td>Triggered after the list of options has been filtered by the user's search term. The provided search term is an unmodified version of the user's search term. Please note that the option filtering will have been case insensitive.</td>
+        </tr>
+        <tr>
+            <td>onPopupCreated</td>
+            <td>The SellecktPopup instance</td>
+            <td>Triggered when a popup instance is created. Useful to bind to events triggered by both the `SellecktPopup` itself, or its DOM element (`popup.$popup`)
+            </td>
+        </tr>
+        <tr>
+            <td>itemsUpdated</td>
+            <td>
+                <ul>
+                    <li>`items` - all the items</li>
+                    <li>`newItems` - items that were added</li>
+                    <li>`removedItems` - items that were removed</li>
+                    <li>`selectedItems` - all items that are now selected</li>
+                </ul>
+            </td>
+            <td>Triggered when the `option` elements in the replaced select element change . Uses a Mutation Observer under the hood</td>
         </tr>
     </tbody>
 </table>

--- a/demo/css/selleckt.css
+++ b/demo/css/selleckt.css
@@ -1,3 +1,7 @@
+body.no-scroll {
+    overflow: hidden;
+}
+
 .selleckt * {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -32,6 +36,11 @@
 
 .selleckt .item.highlighted{
     background-color: rgba(0, 0, 0, 0.2);
+    outline: 0;
+}
+
+.selleckt .item:focus{
+    outline: 0;
 }
 
 .selleckt > .selected:hover,
@@ -59,10 +68,6 @@
     padding: 0;
 }
 .selleckt .items {
-    display: none;
-    position: absolute;
-    left: 0;
-    top: 100%;
     margin-top: -1px;
     width: 100%;
     z-index: 10;

--- a/demo/index.html
+++ b/demo/index.html
@@ -90,6 +90,8 @@
 $select3.selleckt({
     mainTemplate : fancyTemplate,  //view source for this
     selectionTemplate: selectionTemplate, //and view source for this too
+    itemTemplate: fancyItemTemplate, //and view source for one
+    popupTemplate: fancyPopupTemplate, //and finally, view source for this one
     selectedClass: 'selected',
     selectedTextClass: 'selectedText',
     itemsClass: 'items',
@@ -143,21 +145,26 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                 <div class="selected">
                     <span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>
                 </div>
-                <div class="items">
-                    <ul class="{{itemslistClass}}">
-                        {{#items}}
-                        <li class="item" data-text="{{label}}" data-value="{{value}}">
-                            {{label}}
-                        </li>
-                        {{/items}}
-                    </ul>
-                    <span class="noitemsText">No items</span>
-                    <footer>
-                    <hr/>
-                    <a class="add">Add something</a> | <a target="_blank" href="http://google.com">Google</a>
-                    </footer>
-                </div>
             </div>
+        </script>
+        <script id="fancyPopupTemplate" type="text/html">
+            <div class="items" tabindex=1>
+                <ul class="{{itemslistClass}}">
+                    {{#items}}
+                        {{> item}}
+                    {{/items}}
+                </ul>
+                <span class="noitemsText">No items</span>
+                <footer>
+                <hr/>
+                <a class="add">Add something</a> | <a target="_blank" href="http://google.com">Google</a>
+                </footer>
+            </div>
+        </script>
+        <script id="fancyItemTemplate" type="text/html">
+            <li class="item" data-text="{{label}}" data-value="{{value}}">
+                {{label}}
+            </li>
         </script>
         <script id="fancySelectionTemplate" type="text/html">
             <li class="selectionItem" data-value="{{value}}">
@@ -179,7 +186,9 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     $select5 = $('#demo-5'),
                     $select6 = $('#demo-6'),
                     fancyTemplate = document.getElementById('fancyTemplate').innerHTML,
-                    fancySelectionTemplate = document.getElementById('fancySelectionTemplate').innerHTML;
+                    fancySelectionTemplate = document.getElementById('fancySelectionTemplate').innerHTML,
+                    fancyItemTemplate = document.getElementById('fancyItemTemplate').innerHTML,
+                    fancyPopupTemplate = document.getElementById('fancyPopupTemplate').innerHTML;
 
                 $select1.selleckt();
 
@@ -192,16 +201,17 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                 $select4.selleckt({
                     mainTemplate : fancyTemplate,
                     selectionTemplate: fancySelectionTemplate,
+                    itemTemplate: fancyItemTemplate,
+                    popupTemplate: fancyPopupTemplate,
                     showEmptyList: true
                 });
 
-                $select4.data('selleckt').$sellecktEl
-                    .on('click', '.add', function(e){
+                $select4.data('selleckt').bind('onPopupCreated', function(popup){
+                    popup.$popup.on('click', '.add', function(e){
                         e.preventDefault();
                         e.stopPropagation();
                         window.alert('Hey, you clicked the "add button"');
-                    })
-                    .on('click', '.edit', function(e){
+                    }) .on('click', '.edit', function(e){
                         e.preventDefault();
                         e.stopPropagation();
 
@@ -209,6 +219,7 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
 
                         window.alert('Hey, you clicked the "edit button" for item: ' + JSON.stringify(item));
                     });
+                });
 
                 $select5.selleckt();
                 $('.demo-5 #addButton').click(function (){

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -63,7 +63,7 @@ module.exports = function(config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome', 'Safari', 'Firefox'],
+        browsers: ['Chrome','Safari','Firefox'],
 
 
         // Continuous Integration mode

--- a/lib/MultiSelleckt.js
+++ b/lib/MultiSelleckt.js
@@ -37,7 +37,48 @@ function MultiSelleckt(options){
 
 MultiSelleckt.prototype = Object.create(SingleSelleckt.prototype);
 
-MultiSelleckt.prototype.selectItem = function(item){
+MultiSelleckt.prototype._mutationHandler = function (mutations){
+    var newItems = [],
+        removedItems = [],
+        selectedItems = [];
+
+    _.forEach(mutations, function(mutation) {
+        newItems = newItems.concat(this._getItemsFromNodes(mutation.addedNodes));
+        removedItems = removedItems.concat(this._getItemsFromNodes(mutation.removedNodes));
+    }, this);
+
+    this.items = this.items.concat(newItems);
+
+    if(removedItems.length){
+        _.forEach(removedItems, function(item){
+            this.unselectItem(item, {silent: true});
+        }, this);
+
+        this.items = _.reject(this.items, function(item){
+            return _.any(removedItems, function(removedItem){
+                return removedItem.value === item.value;
+            });
+        });
+    }
+
+    _.forEach(this.items, function(item){
+        if(item.isSelected){
+            this.selectItem(item, {silent: true});
+            selectedItems.push(item);
+        }
+    }, this);
+
+    this.trigger('itemsUpdated', {
+        items: this.items,
+        newItems: newItems,
+        removedItems: removedItems,
+        selectedItems: selectedItems
+    });
+};
+
+MultiSelleckt.prototype.selectItem = function(item, options){
+    options = options || {};
+
     if(!this.selectedItems){
         this.selectedItems = [];
     }
@@ -51,11 +92,11 @@ MultiSelleckt.prototype.selectItem = function(item){
 
     this.$sellecktEl.find('.'+this.selectedTextClass).text(this.alternatePlaceholder);
 
-    this.findItemInList(item).hide();
-
     this.toggleDisabled();
 
-    this.updateOriginalSelect();
+    if (!options.silent) {
+        this.updateOriginalSelect();
+    }
 
     this.trigger('itemSelected', item);
 };
@@ -100,6 +141,17 @@ MultiSelleckt.prototype.parseItems = function($selectEl){
     this.selectedItems = itemsObj.selectedItems;
 };
 
+MultiSelleckt.prototype.getItemsForPopup = function() {
+    var showSelectedItem = !this.hideSelectedItem;
+    var selectedValues = _.map(this.selectedItems, function(item){
+        return item.value;
+    });
+
+    return showSelectedItem ? this.items : _.filter(this.items, function(item){
+        return _.indexOf(selectedValues, item.value) === -1;
+    }, this);
+};
+
 MultiSelleckt.prototype.render = function(){
     SingleSelleckt.prototype.render.call(this);
 
@@ -129,12 +181,6 @@ MultiSelleckt.prototype.bindEvents = function(){
     SingleSelleckt.prototype.bindEvents.call(this);
 };
 
-MultiSelleckt.prototype.hideSelectionFromChoices = function(){
-    _(this.selectedItems).each(function(item){
-        this.findItemInList(item).hide();
-    }, this);
-};
-
 MultiSelleckt.prototype.getItemTemplateData = function(item){
     return {
         text: item.label,
@@ -154,10 +200,10 @@ MultiSelleckt.prototype.buildItem = function(item){
     return $html.data('item', item);
 };
 
-MultiSelleckt.prototype.unselectItem = function(item){
-    this.$selections.find('[data-value="' + item.value +'"]').remove();
+MultiSelleckt.prototype.unselectItem = function(item, options){
+    options = options || {};
 
-    this.findItemInList(item).show();
+    this.$selections.find('[data-value="' + item.value +'"]').remove();
 
     this.selectedItems = _(this.selectedItems).reject(function(candidate){
         return candidate === item;
@@ -167,7 +213,9 @@ MultiSelleckt.prototype.unselectItem = function(item){
         this.$sellecktEl.find('.'+this.selectedTextClass).text(this.placeholderText);
     }
 
-    this.updateOriginalSelect();
+    if(!options.silent){
+        this.updateOriginalSelect();
+    }
 
     this.toggleDisabled();
 

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -52,8 +52,14 @@ function SellecktPopup(options){
 
 _.extend(SellecktPopup.prototype, {
 
-    open: function($opener, items) {
+    open: function($opener, items, options) {
+        options = options || {};
+
         var $popup = this.$popup = createPopup();
+
+        if(options.css){
+            $popup.css(options.css);
+        }
 
         this.$opener = $opener;
 

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -107,11 +107,11 @@ _.extend(SellecktPopup.prototype, {
         var templateData = _.extend({
                 items: items
             }, this.getTemplateData()),
-            $rendered = Mustache.render(this.template, templateData, {
+            rendered = Mustache.render(this.template, templateData, {
                 item: this.itemTemplate
             });
 
-        this.$popup.html($rendered);
+        this.$popup.html(rendered);
     },
 
     refreshItems: function(items){

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -224,8 +224,6 @@ _.extend(SellecktPopup.prototype, {
             }
 
             e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
 
             if(e.which === KEY_CODES.ESC){
                 return self.close();
@@ -272,10 +270,6 @@ _.extend(SellecktPopup.prototype, {
         if(this.showSearch){
             $searchInput = $popup.find(searchInputClass);
 
-            $searchInput.on('click', function(e){
-                e.stopPropagation();
-            });
-
             $searchInput.on('keydown', function(e){
                 var whichKey = e.which;
 
@@ -303,6 +297,15 @@ _.extend(SellecktPopup.prototype, {
                 trigger('search', term);
             }));
         }
+
+        $popup.on('click', function(e){
+            var $target = $(e.target);
+
+            if($target.is(itemClass) || $target.is(searchInputClass)){
+                return;
+            }
+            self.close();
+        });
     },
 
     _positionPopup: function($opener, options){

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -1,0 +1,347 @@
+'use strict';
+
+var KEY_CODES = require('./KEY_CODES');
+var TEMPLATES = require('./TEMPLATES');
+var templateUtils = require('./templateUtils');
+
+var $ = require('jquery');
+var _ = require('underscore');
+var Mustache = require('Mustache');
+var MicroEvent = require('./MicroEvent');
+
+function createPopup(){
+    return $('<div>', {
+        'class': 'sellecktPopup selleckt',
+    });
+}
+
+function attachPopup($popup, $attachTarget){
+    $attachTarget.find('.sellecktPopup').remove();
+    $popup.appendTo($attachTarget);
+}
+
+function SellecktPopup(options){
+    var settings = _.defaults(options || {}, {
+        template: TEMPLATES.ITEMS_CONTAINER,
+        itemTemplate: TEMPLATES.SINGLE_ITEM,
+        templateData: {},
+        itemsClass : 'items',
+        itemslistClass : 'itemslist',
+        itemClass : 'item',
+        itemTextClass: 'itemText',
+        highlightClass : 'highlighted',
+        searchInputClass: 'search',
+        showSearch: false
+    });
+
+    this.template = settings.template;
+    this.templateData = settings.templateData;
+    this.itemTemplate = settings.itemTemplate;
+    this.itemsClass = settings.itemsClass;
+    this.itemslistClass = settings.itemslistClass;
+    this.itemClass = settings.itemClass;
+    this.itemTextClass = settings.itemTextClass;
+    this.highlightClass = settings.highlightClass;
+
+    this.searchInputClass = settings.searchInputClass;
+    this.showSearch = settings.showSearch;
+
+    templateUtils.cacheTemplate(this.template);
+    templateUtils.cacheTemplate(this.itemTemplate);
+}
+
+_.extend(SellecktPopup.prototype, {
+
+    open: function($opener, items) {
+        var $popup = this.$popup = createPopup();
+
+        this.$opener = $opener;
+
+        this.renderItems(items);
+
+        attachPopup($popup, $('body'));
+        this._positionPopup($opener);
+
+        this.bindEvents();
+        this._attachResizeHandler($opener);
+
+        if (this.showSearch) {
+            $popup.find('.'+this.searchInputClass).focus();
+        } else {
+            //NB: set the tabindex so we can apply focus, which makes the key handling work
+            $popup.find('.'+this.itemClass).first().attr('tabindex',-1).focus();
+        }
+    },
+
+    close: function() {
+        this._removeResizeHandler();
+
+        this.$opener = undefined;
+
+        if(this.$popup){
+            this.$popup.remove();
+            this.$popup = undefined;
+
+            this.trigger('close');
+        }
+    },
+
+    getTemplateData: function() {
+        return _.extend(this.templateData, {
+            showSearch : this.showSearch,
+            itemsClass: this.itemsClass,
+            itemslistClass : this.itemslistClass,
+            itemClass: this.itemClass,
+            itemTextClass: this.itemTextClass,
+            searchInputClass: this.searchInputClass
+        });
+    },
+
+    renderItems: function(items) {
+        var templateData = _.extend({
+                items: items
+            }, this.getTemplateData()),
+            $rendered = Mustache.render(this.template, templateData, {
+                item: this.itemTemplate
+            });
+
+        this.$popup.html($rendered);
+    },
+
+    refreshItems: function(items){
+        var $rendered = _.map(items, function(item){
+            var itemEl = Mustache.render(this.itemTemplate, {
+                itemTextClass: this.itemTextClass,
+                itemClass: this.itemClass,
+                label: item.label,
+                value: item.value
+            });
+
+            if(item.matchEnd > 0){
+                return this._addMarkToItem(itemEl, item);
+            }
+
+            return itemEl;
+        }, this);
+
+        this.$popup.find('.'+this.itemslistClass).html($rendered);
+
+        this.$popup.toggleClass('noitems', !items.length);
+
+        if(this.$popup.hasClass('flipped')){
+            //we may need to reposition the popup as it's positioned using top
+            this._positionPopup(this.$opener, {keepCurrentOrientation: true});
+        }
+    },
+
+    _addMarkToItem: function(itemEl, item){
+        var $itemEl = $(itemEl),
+            $textContainer = $itemEl.find('.' + this.itemTextClass),
+            markStart = '<mark>',
+            markEnd = '</mark>',
+            html;
+
+        html = _.escape(item.label.substring(0, item.matchStart)) +
+                markStart +
+                _.escape(item.label.slice(item.matchStart, item.matchEnd + 1)) +
+                markEnd +
+                _.escape(item.label.substring(item.matchEnd + 1));
+
+        $textContainer.html(html);
+
+        return $itemEl;
+    },
+
+    bindEvents: function() {
+        var self = this,
+            lockMousover = false,
+            highlightClass = this.highlightClass,
+            itemClass = '.'+this.itemClass,
+            itemslistClass = '.'+this.itemslistClass,
+            $popup = this.$popup,
+            itemslist = $popup.find(itemslistClass)[0],
+            trigger = _.bind(this.trigger, this),
+            searchInputClass = '.'+this.searchInputClass,
+            $searchInput;
+
+        function getHighlightItem(){
+            return $popup.find('.' + highlightClass);
+        }
+
+        function highlightItem($item){
+            $popup.find(itemClass).removeClass(highlightClass);
+
+            $item.addClass(highlightClass).attr('tabindex', -1).focus();
+        }
+
+        function selectItem($target){
+            trigger('valueSelected', $target.attr('data-value'));
+
+            self.close();
+        }
+
+        function scrollItems(offset, absolute){
+            lockMousover = true;
+            if (absolute) {
+                itemslist.scrollTop = offset;
+            } else {
+                itemslist.scrollTop += offset;
+            }
+
+            _.delay(function(){
+                lockMousover = false;
+            }, 200);
+        }
+
+        $popup.on('mouseover', itemClass, function(e){
+            if (lockMousover) {
+                return;
+            }
+            highlightItem($(e.currentTarget));
+        });
+
+        $popup.on('click', itemClass, function(e){
+            e.preventDefault();
+
+            return selectItem($(e.currentTarget));
+        });
+
+        $popup.on('keydown', itemClass, function(e){
+            var whichKey = e.which,
+                $currentHighlightItem,
+                $theItems,
+                $itemToHighlight;
+
+            if(whichKey !== KEY_CODES.DOWN && whichKey !== KEY_CODES.UP &&
+                whichKey !== KEY_CODES.ENTER && whichKey !== KEY_CODES.ESC){
+                return;
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+
+            if(e.which === KEY_CODES.ESC){
+                return self.close();
+            }
+
+            $currentHighlightItem = getHighlightItem();
+
+            if(e.which === KEY_CODES.ENTER){
+                return selectItem($currentHighlightItem);
+            }
+
+            $theItems = $popup.find(itemClass);
+
+            if(whichKey === KEY_CODES.DOWN){
+                $itemToHighlight = $currentHighlightItem.nextAll(itemClass).first();
+
+                if (!$currentHighlightItem.length || !$itemToHighlight.length) {
+                    $itemToHighlight = $theItems.first();
+                    scrollItems(0, true);
+                } else if ($itemToHighlight.offset().top +
+                            $itemToHighlight.outerHeight() >
+                            $popup.offset().top +
+                            $popup.outerHeight()) {
+                    scrollItems($itemToHighlight.outerHeight());
+                }
+
+                return highlightItem($itemToHighlight);
+            }
+
+            if(whichKey === KEY_CODES.UP){
+                $itemToHighlight = $currentHighlightItem.prevAll(itemClass).first();
+
+                if(!$currentHighlightItem.length || !$itemToHighlight.length){
+                    $itemToHighlight = $theItems.last();
+                    scrollItems($itemToHighlight.offset().top, true);
+                } else if ($itemToHighlight.offset().top < $popup.offset().top + $itemToHighlight.outerHeight()) {
+                    scrollItems(-$itemToHighlight.outerHeight());
+                }
+
+                return highlightItem($itemToHighlight);
+            }
+        });
+
+        if(this.showSearch){
+            $searchInput = $popup.find(searchInputClass);
+
+            $searchInput.on('click', function(e){
+                e.stopPropagation();
+            });
+
+            $searchInput.on('keydown', function(e){
+                var whichKey = e.which;
+
+                if(whichKey === KEY_CODES.ESC){
+                    return self.close();
+                }
+
+                if(whichKey === KEY_CODES.DOWN){
+                    e.stopPropagation();
+                    e.preventDefault();
+
+                    return highlightItem($popup.find(itemClass).first());
+                }
+            });
+
+            $searchInput.on('keyup', _.debounce(function(e){
+                var whichKey = e.which;
+
+                if(whichKey === KEY_CODES.ESC || whichKey === KEY_CODES.ENTER){
+                    return;
+                }
+
+                var term = $searchInput.val();
+
+                trigger('search', term);
+            }));
+        }
+    },
+
+    _positionPopup: function($opener, options){
+        options = options || {};
+
+        var $window = $(window),
+            windowHeight = $window.height(),
+            windowScrollTop = $window.scrollTop(),
+            popupHeight = this.$popup.outerHeight(),
+            openerHeight = $opener.outerHeight(),
+            openerOffset = $opener.offset(),
+            viewportBottom = windowScrollTop + windowHeight,
+            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
+            showBelow = enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped')),
+            css = {
+                position: 'absolute',
+                left: openerOffset.left,
+                top: showBelow ? openerOffset.top + openerHeight : openerOffset.top - popupHeight
+            };
+
+        this.$popup.css(css);
+
+        if(options.keepCurrentOrientation !== true){
+            this.$popup.toggleClass('flipped', !showBelow);
+        }
+    },
+
+    _attachResizeHandler: function($opener){
+        var $popup = this.$popup,
+            positionPopup = _.bind(this._positionPopup, this);
+
+        this.resizeHandler = _.throttle(function(){
+            positionPopup($opener, $popup);
+        }, 20);
+
+        $(window).on('resize', this.resizeHandler);
+    },
+
+    _removeResizeHandler: function(){
+        if (this.resizeHandler){
+            $(window).off('resize', this.resizeHandler);
+            this.resizeHandler = undefined;
+        }
+    }
+});
+
+MicroEvent.mixin(SellecktPopup);
+module.exports = SellecktPopup;

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -220,7 +220,9 @@ _.extend(SingleSelleckt.prototype, {
                 memo.selectedItems.push(item);
             }
 
-            memo.items.push(item);
+            if(item.value && item.label){
+                memo.items.push(item);
+            }
 
             return memo;
         }, {

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -166,7 +166,10 @@ _.extend(SingleSelleckt.prototype, {
     },
 
     _onPopupClose: function(){
-        this._removePopup();
+        if (this.$sellecktEl.hasClass('open')){
+            this._close();
+        }
+
         this.$sellecktEl.attr('tabindex', -1).focus();
     },
 

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -395,6 +395,12 @@ _.extend(SingleSelleckt.prototype, {
         this.trigger('itemSelected', item);
     },
 
+    selectItemByValue: function(value, options) {
+        var item = this.findItem(value);
+
+        this.selectItem(item, options);
+    },
+
     updateSelection: function(newSelection){
         this.selectItem(this.findItem(newSelection));
     },

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -3,6 +3,7 @@
 var KEY_CODES = require('./KEY_CODES');
 var TEMPLATES = require('./TEMPLATES');
 var templateUtils = require('./templateUtils');
+var SellecktPopup = require('./SellecktPopup');
 
 var $ = require('jquery');
 var _ = require('underscore');
@@ -13,210 +14,201 @@ function SingleSelleckt(options){
     var settings = _.defaults(options, {
         mainTemplate: TEMPLATES.SINGLE,
         itemTemplate: TEMPLATES.SINGLE_ITEM,
+        popupTemplate: TEMPLATES.ITEMS_CONTAINER,
         mainTemplateData: {},
+        popupTemplateData: {},
         selectedClass : 'selected',
         selectedTextClass : 'selectedText',
-        itemsClass : 'items',
-        itemslistClass : 'itemslist',
-        itemClass : 'item',
         className : 'dropdown selleckt',
-        highlightClass : 'highlighted',
-        itemTextClass: 'itemText',
         placeholderText : 'Please select...',
+        highlightClass : 'highlighted',
         enableSearch : false,
         searchInputClass : 'search',
-        searchThreshold : 0
+        searchThreshold : 0,
+        hideSelectedItem: false
     });
 
     this.$originalSelectEl = options.$selectEl;
 
     this.mainTemplate = settings.mainTemplate;
     this.itemTemplate = settings.itemTemplate;
+    this.popupTemplate = settings.popupTemplate;
     this.mainTemplateData = settings.mainTemplateData;
+    this.popupTemplateData = settings.popupTemplateData;
     this.selectedClass = settings.selectedClass;
     this.selectedTextClass = settings.selectedTextClass;
+    this.className = settings.className;
+    this.placeholderText = settings.placeholderText;
+    this.highlightClass = settings.highlightClass;
+
     this.itemsClass = settings.itemsClass;
     this.itemslistClass = settings.itemslistClass;
     this.itemClass = settings.itemClass;
     this.itemTextClass = settings.itemTextClass;
     this.searchInputClass = settings.searchInputClass;
-    this.className = settings.className;
-    this.highlightClass = settings.highlightClass;
-
-    this.placeholderText = settings.placeholderText;
 
     this.parseItems(this.$originalSelectEl);
 
     this.showSearch = (settings.enableSearch &&
                         this.items.length > settings.searchThreshold);
 
+    this.hideSelectedItem = settings.hideSelectedItem;
+
     this.id = _.uniqueId('selleckt');
 
     templateUtils.cacheTemplate(this.mainTemplate);
-    templateUtils.cacheTemplate(this.itemTemplate);
+}
+
+function closeEventHandler(context, event){
+    var eventTrigger = $(event.target).closest('.'+context.selectedClass)[0];
+    var dropdownTrigger = context.$sellecktEl.find('.'+context.selectedClass)[0];
+    var $popup = context.popup && context.popup.$popup;
+
+    //prevent the dropdown from closing immediately when the 'click' event propagates to the document
+    if(eventTrigger === dropdownTrigger && event.currentTarget === document){
+        return;
+    }
+
+    var anyParentIsPopup = $popup && _.any($(event.target).parents(), function(parent) {
+        return $(parent).is($popup);
+    });
+
+    if(anyParentIsPopup){
+        return;
+    }
+
+    context._close();
 }
 
 SingleSelleckt.prototype.DELAY_TIMEOUT = 0;
 
-function getScrollingParent($el){
-    var $scrollingParent;
-
-    $el.parents().each(function(idx, elem){
-        var $elem = $(elem);
-        if(_(['auto', 'scroll']).indexOf($elem.css('overflow-y')) > -1){
-            $scrollingParent = $elem;
-            return false;
-        }
-    });
-
-    return $scrollingParent || $(window);
-}
-
-function getOverflowHiddenParent($el){
-    var $overflowHiddenParent;
-
-    $el.parents().each(function(idx, elem){
-        var $elem = $(elem),
-            elemOverflowY = $elem.css('overflow-y'),
-            elemMaxHeight = $elem.css('max-height');
-
-        if((elemOverflowY==='hidden' && elemMaxHeight!=='auto') || _(['auto', 'scroll']).indexOf(elemOverflowY) > -1){
-            $overflowHiddenParent = $elem;
-            return false;
-        }
-    });
-
-    return $overflowHiddenParent;
-}
-
 _.extend(SingleSelleckt.prototype, {
 
     _open: function() {
-        var $sellecktEl = this.$sellecktEl,
-            closeFunc;
+        var $sellecktEl = this.$sellecktEl;
 
         if($sellecktEl.hasClass('disabled')){
             return;
         }
 
-        this.$items.show();
-        this.$sellecktEl.addClass('open').removeClass('closed');
-
-        if(this.showSearch){
-            this.clearSearch();
-        }
-
-        closeFunc = _.bind(this._close, this);
-
-        $(document).off('click.selleckt-' + this.id);
-        $(document).on('click.selleckt-' + this.id, closeFunc);
-
-        if(this._isOverflowing()) {
-            this._setItemsFixed();
-            this.$scrollingParent.off('scroll.selleckt-' + this.id);
-            this.$scrollingParent.on('scroll.selleckt-' + this.id, closeFunc);
-        } else {
-            this._setItemsAbsolute();
-        }
-
-        this.$items.find('.'+this.searchInputClass).focus();
-    },
-
-    _close: function(event) {
-        var dropdownTrigger = this.$sellecktEl.find('.'+this.selectedClass)[0],
-            eventTrigger = event ? $(event.target).closest('.'+this.selectedClass)[0] : undefined;
-
-        // prevent the dropdown from closing immediately when the 'click' event propagates to the document
-        if(eventTrigger===dropdownTrigger && event.currentTarget===document) {
+        if(this.popup){
             return;
         }
 
-        this.$items.find('.'+this.highlightClass).removeClass(this.highlightClass);
-        this.$items.find('.'+this.itemslistClass).scrollTop(0);
+        this.popup = this._makePopup();
 
-        this.$items.hide().removeClass('flipped');
+        $sellecktEl.addClass('open').removeClass('closed');
+
+        $(document)
+            .off('click.selleckt-' + this.id)
+            .on('click.selleckt-' + this.id, _.bind(closeEventHandler, this, this));
+
+        $('body').addClass('no-scroll');
+    },
+
+    _close: function() {
+        $(document).off('click.selleckt-' + this.id);
+
         this.$sellecktEl.removeClass('open').addClass('closed');
 
-        if(this.showSearch){
-            this.clearSearch();
-        }
-
-        $(document).off('click.selleckt-' + this.id);
-        this.$scrollingParent.off('scroll.selleckt-' + this.id);
+        this._removePopup();
 
         this.trigger('close');
+
+        $('body').removeClass('no-scroll');
     },
 
-    _isOverflowing: function(){
-        if(!this.$overflowHiddenParent) {
-            return false;
+    _removePopup: function() {
+        if(this.popup){
+            this.popup.unbind('valueSelected', this.onPopupValueSelected);
+            this.popup.close();
+            this.popup = undefined;
         }
-
-        var $dropdownTrigger = this.$items.prev(),
-            itemsBottom = $dropdownTrigger.offset().top + $dropdownTrigger.outerHeight() + this.$items.height(),
-            overflowHiddenParentBottom = this.$overflowHiddenParent.offset().top + this.$overflowHiddenParent.height();
-
-        return itemsBottom > overflowHiddenParentBottom;
     },
 
-    _flipIfNeeded: function() {
-        var $items = this.$items,
-            itemsHeight = $items.outerHeight(),
-            $window = $(window),
-            windowHeight = $window.height(),
-            scrollDistance = $window.scrollTop(),
-            dropdownBottom = $items.offset().top - scrollDistance + itemsHeight,
-            bottomSpace = windowHeight - dropdownBottom,
-            topSpace, $dropdownTrigger, triggerTop, newDropdownBottom;
+    getItemsForPopup: function() {
+        var showSelectedItem = !this.hideSelectedItem;
+        var itemsToShow =  showSelectedItem ? this.items : _.filter(this.items, function(item){
+            return this.selectedItem !== item;
+        }, this);
 
-        if(bottomSpace > -1) { // there's enough space below the trigger
-            return;
-        }
-
-        $dropdownTrigger = this.$sellecktEl.find('.'+this.selectedClass);
-        triggerTop = $dropdownTrigger.offset().top - scrollDistance;
-        newDropdownBottom = windowHeight - triggerTop;
-        topSpace = windowHeight - (newDropdownBottom + itemsHeight);
-
-        if(topSpace < 0) { // don't go off screen on top
-            newDropdownBottom = newDropdownBottom + topSpace;
-        }
-
-        // when the dropdown is flipped it is positioned via 'bottom' rather than 'top' so that
-        // it won't "detach" from the trigger when the search is used and its height changes
-        $items.css({
-            top: 'auto',
-            bottom: newDropdownBottom
-        }).addClass('flipped');
+        return itemsToShow;
     },
 
-    _setItemsFixed: function(){
-        var $dropdownTrigger = this.$sellecktEl.find('.'+this.selectedClass),
-            $triggerOffset = $dropdownTrigger.offset(),
-            $window = $(window);
-
-        this.$items.css({
-            width: 'inherit',
-            position: 'fixed',
-            top: ($triggerOffset.top - $window.scrollTop() + $dropdownTrigger.outerHeight()) + 'px',
-            left: ($triggerOffset.left - $window.scrollLeft()) + 'px',
-            bottom: 'auto'
+    _makePopup: function() {
+        var popup = new SellecktPopup({
+            template: this.popupTemplate,
+            templateData: this.popupTemplateData,
+            itemTemplate: this.itemTemplate,
+            itemsClass: this.itemsClass,
+            itemslistClass : this.itemslistClass,
+            itemClass: this.itemClass,
+            itemTextClass: this.itemTextClass,
+            searchInputClass: this.searchInputClass,
+            showSearch: this.showSearch
         });
 
-        this._flipIfNeeded();
+        popup.open(this.$sellecktEl, this.getItemsForPopup());
+
+        popup.bind('close', _.bind(this._onPopupClose, this));
+        popup.bind('valueSelected', _.bind(this._onPopupValueSelected, this));
+        popup.bind('search', _.bind(this._refreshPopupWithSearchHits, this));
+
+        this.trigger('onPopupCreated', popup);
+
+        return popup;
     },
 
-    _setItemsAbsolute: function(){
-        this.$items.css({
-            position: 'absolute',
-            top: 'auto',
-            left: 'auto',
-            bottom: 'auto'
-        });
+    _onPopupClose: function(){
+        this._removePopup();
+        this.$sellecktEl.attr('tabindex', -1).focus();
+    },
+
+    _onPopupValueSelected: function(value){
+        var item = this.findItem(value);
+
+        this.selectItem(item);
+    },
+
+    _filterItems: function(items, term){
+        if(!term){
+            return items;
+        }
+
+        return _.reduce(items, function(memo, item){
+            var matchIndex;
+
+            if (!item.value) {
+                return memo;
+            }
+
+            matchIndex = item.label.toLowerCase().indexOf(term);
+
+            if(matchIndex === -1){
+                return memo;
+            }
+
+            memo.push(_.extend({}, item, {
+                matchStart: matchIndex,
+                matchEnd: matchIndex + (term.length - 1)
+            }));
+
+            return memo;
+        }, []);
+    },
+
+    _refreshPopupWithSearchHits: function(term){
+        var matchingItems = this._filterItems(this.items, term);
+
+        this.popup.refreshItems(matchingItems);
+
+        if(matchingItems.length < this.items.length){
+            this.trigger('optionsFiltered', term);
+        }
     },
 
     _parseItemsFromOptions: function($selectEl){
-        return _($selectEl.find('option')).reduce(function(memo, option){
+        return _.reduce($selectEl.find('option'), function(memo, option){
             var $option = $(option),
                 item = {
                     value: $option.val(),
@@ -253,40 +245,56 @@ _.extend(SingleSelleckt.prototype, {
         return $option;
     },
 
-    _createSellecktItem: function(item){
-        return Mustache.render(this.itemTemplate, _.extend({
-            itemClass: this.itemClass,
-            itemTextClass: this.itemTextClass,
-        }, item));
-    },
-
     _getItemsFromNodes: function(nodeList){
         return _.map(nodeList, function(node){
             return {
                 value: node.value,
                 label: node.text,
-                isSelected: node.selected
+                isSelected: node.selected || undefined
             };
         });
     },
 
     _mutationHandler: function (mutations){
-        var createSellecktItem = _.bind(this._createSellecktItem, this),
-            $items = this.$sellecktEl.find('.' + this.itemslistClass),
-            findItemInList = _.bind(this.findItemInList, this),
-            itemsFromNodes = _.bind(this._getItemsFromNodes, this),
-            newItems = [],
-            removedItems = [];
+        var newItems = [],
+            removedItems = [],
+            selectedItems = [];
 
-        _.each(mutations, function(mutation) {
-            newItems = newItems.concat(itemsFromNodes(mutation.addedNodes));
-            removedItems = removedItems.concat(itemsFromNodes(mutation.removedNodes));
-        });
+        _.forEach(mutations, function(mutation) {
+            newItems = newItems.concat(this._getItemsFromNodes(mutation.addedNodes));
+            removedItems = removedItems.concat(this._getItemsFromNodes(mutation.removedNodes));
+        }, this);
 
-        $items.append(_.map(newItems, createSellecktItem));
+        this.items = this.items.concat(newItems);
 
-        _.each(removedItems, function(item){
-            findItemInList(item).remove();
+        if(removedItems.length){
+            this.items = _.reject(this.items, function(item){
+                return _.any(removedItems, function(removedItem){
+                    return removedItem.value === item.value;
+                });
+            });
+        }
+
+        _.forEach(this.items, function(item){
+            if(item.isSelected){
+                this.selectItem(item, {silent: true});
+                selectedItems.push(item);
+            }
+        }, this);
+
+        if(!selectedItems.length){
+            this.selectedItem = undefined;
+
+            if(this.$sellecktEl){
+                this.$sellecktEl.find('.'+this.selectedTextClass).text(this.placeholderText);
+            }
+        }
+
+        this.trigger('itemsUpdated', {
+            items: this.items,
+            newItems: newItems,
+            removedItems: removedItems,
+            selectedItems: selectedItems
         });
     },
 
@@ -311,186 +319,30 @@ _.extend(SingleSelleckt.prototype, {
 
     bindEvents: function(){
         var self = this,
-            itemClass = '.'+this.itemClass,
-            searchInputClass = '.'+this.searchInputClass,
-            highlightClass = this.highlightClass,
             $sellecktEl = this.$sellecktEl,
             $originalSelectEl = this.$originalSelectEl,
-            $items = this.$items,
-            itemslist = $items.find('.'+this.itemslistClass)[0],
-            $selected = $sellecktEl.find('> .' + this.selectedClass),
-            $searchInput = $sellecktEl.find(searchInputClass),
-            filterOptions = _.bind(this.filterOptions, this),
-            lockMousover = false,
-            scrollNotch2PixelRatio = -40,
-            scrollStepPx = 80,
-            throttleMs = 50,
-            // based on: http://stackoverflow.com/questions/16323770/stop-page-from-scrolling-if-hovering-div/16324663#16324663
-            scrollFunc = function(ev) {
-                var $this = $(this),
-                    scrollTop = this.scrollTop,
-                    scrollHeight = this.scrollHeight,
-                    height = $this.height(),
-                    delta = (ev.type === 'DOMMouseScroll' ?
-                            ev.originalEvent.detail * scrollNotch2PixelRatio :
-                            ev.originalEvent.wheelDelta),
-                    up = delta > 0,
-                    prevent = function() {
-                        function isOpen(el){
-                            return $(el).parents('.selleckt').hasClass('open');
-                        }
+            $selected = $sellecktEl.find('> .' + this.selectedClass);
 
-                        if(!isOpen(ev.target)) {
-                            return;
-                        }
-                        ev.stopPropagation();
-                        ev.preventDefault();
-                        ev.returnValue = false;
-                        return false;
-                    };
+        $sellecktEl.on('keydown', function(e){
+            var whichKey = e.which;
 
-                delta = up ? scrollStepPx : -scrollStepPx; // hardcode same "scroll step" for all browsers
-
-                if (!up && -delta > scrollHeight - height - scrollTop) {
-                    $this.scrollTop(scrollHeight);
-                    return prevent();
-                }
-                if (up && delta > scrollTop) {
-                    $this.scrollTop(0);
-                    return prevent();
-                }
-
-                $this.scrollTop(scrollTop-delta);
-                return prevent();
-            },
-            throttledScrollFunc = _.throttle(scrollFunc, throttleMs);
-
-        function getHighlightItem(){
-            return $items.find('.' + highlightClass);
-        }
-
-        function highlightItem(item){
-            $items
-                .find(itemClass)
-                .removeClass(highlightClass);
-
-            item.addClass(highlightClass);
-        }
-
-        function selectCurrentItem(){
-            var highlightItem = getHighlightItem(),
-                selectedItem = self.findItem(highlightItem.data('value'));
-
-            if(selectedItem){
-                if(self.selectedItem && self.selectedItem.value === selectedItem.value){
-                    return;
-                }
-                self.selectItem(selectedItem);
+            if(whichKey === KEY_CODES.ENTER){
+                self._open();
             }
-
-            self._close();
-
-            return $sellecktEl.focus();
-        }
-
-        function scrollItems(offset, absolute){
-            lockMousover = true;
-            if (absolute) {
-                itemslist.scrollTop = offset;
-            } else {
-                itemslist.scrollTop += offset;
-            }
-
-            _.delay(function(){
-                lockMousover = false;
-            }, 200);
-        }
+        });
 
         $selected.on('click', function() {
             self.$sellecktEl.focus();
 
-            if (self.$items.is(':visible')) {
+            if ($sellecktEl.hasClass('open')) {
                 return self._close();
             }
 
             self._open();
         });
 
-        $items.on('click', itemClass, function(e){
-            e.stopPropagation();
-
-            $sellecktEl.focus();
-
-            selectCurrentItem($(e.target));
-        }).on('mouseover', itemClass, function(e){
-            if (lockMousover) {
-                return;
-            }
-            highlightItem($(e.currentTarget));
-        });
-
-        $sellecktEl.on('keyup', function(e){
-            var keyCode = e.keyCode;
-
-            if(keyCode === KEY_CODES.ESC){
-                if($sellecktEl.hasClass('open')){
-                    self._close();
-                }
-            }
-        });
-
-        $sellecktEl.on('keydown', function(e){
-            var whichKey = e.which,
-                $currentHighlightItem,
-                $theItems = self.$items.find('.'+self.itemClass),
-                $itemToHighlight;
-
-            if(whichKey === KEY_CODES.DOWN){
-                e.preventDefault();
-
-                $currentHighlightItem = getHighlightItem();
-                $itemToHighlight = $currentHighlightItem.nextAll('.'+self.itemClass+':visible').first();
-
-                if (!$currentHighlightItem.length || !$itemToHighlight.length) {
-                    $itemToHighlight = $theItems.filter(':visible').first();
-                    scrollItems(0, true);
-                } else if ($itemToHighlight.offset().top + $itemToHighlight.outerHeight() > $items.offset().top + $items.outerHeight()) {
-                    scrollItems($itemToHighlight.outerHeight());
-                }
-                return highlightItem($itemToHighlight);
-            }
-
-            if(whichKey === KEY_CODES.UP){
-                e.preventDefault();
-
-                $currentHighlightItem = getHighlightItem();
-                $itemToHighlight = $currentHighlightItem.prevAll('.'+self.itemClass+':visible').first();
-
-                if(!$currentHighlightItem.length || !$itemToHighlight.length){
-                    $itemToHighlight = $theItems.filter(':visible').last();
-                    scrollItems($itemToHighlight.offset().top, true);
-                } else if ($itemToHighlight.offset().top < $items.offset().top + $itemToHighlight.outerHeight()) {
-                    scrollItems(-$itemToHighlight.outerHeight());
-                }
-
-                return highlightItem($itemToHighlight);
-            }
-
-            if(whichKey === KEY_CODES.ENTER){
-                e.preventDefault();
-
-                if (self.$items.is(':visible')) {
-                    return selectCurrentItem();
-                }
-
-                self._open();
-
-                highlightItem($theItems.filter(':visible').first());
-            }
-        });
-
         $originalSelectEl.on('change.selleckt', function(e, data) {
-            if(data && data.origin==='selleckt') {
+            if(data && data.origin === 'selleckt') {
                 return;
             }
 
@@ -498,23 +350,6 @@ _.extend(SingleSelleckt.prototype, {
             self.updateSelection(newSelection);
             e.stopImmediatePropagation();
         });
-
-        if(this._isOverflowing()) {
-            $sellecktEl.find('.'+this.selectedClass+', .'+this.itemsClass+', .'+this.itemslistClass)
-                .on('DOMMouseScroll mousewheel', throttledScrollFunc);
-        }
-
-        if(this.showSearch){
-            $searchInput.on('click', function(e){
-                e.stopPropagation();
-            });
-
-            $searchInput.on('keyup', _.debounce(function(){
-                var term = $searchInput.val();
-
-                filterOptions(term);
-            }));
-        }
     },
 
     parseItems: function($selectEl){
@@ -527,10 +362,6 @@ _.extend(SingleSelleckt.prototype, {
         }
     },
 
-    findItemInList: function(item){
-        return this.$sellecktEl.find('.'+this.itemClass+'[data-value="' + item.value + '"]');
-    },
-
     findItem: function(value){
         return _(this.items).find(function(item){
             /*jshint eqeqeq:false*/
@@ -538,30 +369,18 @@ _.extend(SingleSelleckt.prototype, {
         });
     },
 
-    hideSelectionFromChoices: function(){
-        if(!this.$sellecktEl){
-            return;
-        }
-
-        if(this.selectedItem){
-            this.findItemInList(this.selectedItem).hide();
-        }
-    },
-
     selectItem: function(item, options){
-        var selectedItem = this.selectedItem,
-            $sellecktEl = this.$sellecktEl,
+        var $sellecktEl = this.$sellecktEl,
             displayedLabel = (item && item.label) || this.placeholderText;
 
         item = item || {};
         options = options || {};
 
-        if(selectedItem){
-            this.findItemInList(selectedItem).show();
+        if(item === this.selectedItem){
+            return;
         }
 
         if($sellecktEl){
-            this.findItemInList(item).hide();
             $sellecktEl.find('.'+this.selectedTextClass).text(displayedLabel);
         }
 
@@ -570,8 +389,6 @@ _.extend(SingleSelleckt.prototype, {
         if (!options.silent) {
             this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
         }
-
-        this.hideSelectionFromChoices();
 
         this.trigger('itemSelected', item);
     },
@@ -592,18 +409,14 @@ _.extend(SingleSelleckt.prototype, {
             selectedItemText: selectedItem && selectedItem.label || this.placeholderText,
             className : this.className,
             selectedClass: this.selectedClass,
-            selectedTextClass: this.selectedTextClass,
-            itemsClass: this.itemsClass,
-            itemslistClass : this.itemslistClass,
-            itemClass: this.itemClass,
-            itemTextClass: this.itemTextClass,
-            searchInputClass: this.searchInputClass,
-            items: this.items
+            selectedTextClass: this.selectedTextClass
         });
     },
 
     addItems: function(items){
-        var selectItem = _.bind(this.selectItem, this);
+        //stop observing mutations, else we'll get into a loop
+        this._stopObservingMutations();
+
         var $options = _.map(items, function(item){
             return this._createOptionFromItem(item);
         }, this);
@@ -612,74 +425,65 @@ _.extend(SingleSelleckt.prototype, {
 
         this.items = this.items.concat(items);
 
-        var selectedItem = _.find(items, function(item){
-            return item.isSelected;
-        });
+        _.forEach(items, function(item) {
+            if (item.isSelected){
+                this.selectItem(item);
+            }
+        }, this);
 
-        if(!selectedItem){
-            return;
-        }
-
-        _.delay(function(){
-            selectItem(selectedItem);
-        }, this.DELAY_TIMEOUT);
+        //start observing mutations again
+        this._observeMutations(this.$originalSelectEl[0]);
     },
 
     addItem: function(item){
-        var $option = this._createOptionFromItem(item);
-        var selectItem = _.bind(this.selectItem, this);
+        //stop observing mutations, else we'll get into a loop
+        this._stopObservingMutations();
 
-        $option.appendTo(this.$originalSelectEl);
+        this._createOptionFromItem(item).appendTo(this.$originalSelectEl);
 
         this.items.push(item);
 
-        if(!item.isSelected){
-            return;
+        if(item.isSelected){
+            this.selectItem(item);
         }
 
-        //defer this because we hook into the mutation
-        //event in order to populate Selleckt, and that
-        //event fires asynchronously
-        _.delay(function(){
-            selectItem(item);
-        }, this.DELAY_TIMEOUT);
+        //start observing mutations again
+        this._observeMutations(this.$originalSelectEl[0]);
     },
 
     removeItem: function(value){
-        this.items = _.filter(this.items, function(item){
-            /*jshint eqeqeq:false*/
-            return item.value != value;
-        });
-
-        if(this.selectedItem && this.selectedItem.value === value){
-            this.selectedItem = undefined;
-            this.$sellecktEl.find('.'+this.selectedTextClass).text(this.placeholderText);
-        }
+        //stop observing mutations, else we'll get into a loop
+        this._stopObservingMutations();
 
         this.$originalSelectEl.find('option[value="' + value +'"]').remove();
+
+        this.items = _.filter(this.items, function(item){
+            return value !== item.value;
+        });
+
+        if(this.selectedItem.value === value){
+            if(this.$sellecktEl){
+                this.$sellecktEl.find('.'+this.selectedTextClass).text(this.placeholderText);
+            }
+
+            this.selectedItem = undefined;
+        }
+
+        //start observing mutations again
+        this._observeMutations(this.$originalSelectEl[0]);
     },
 
     render: function(){
         var templateData = this.getTemplateData(),
             $originalSelectEl = this.$originalSelectEl,
-            rendered = Mustache.render(this.mainTemplate, templateData, {
-                item: this.itemTemplate
-            }),
+            rendered = Mustache.render(this.mainTemplate, templateData),
             $sellecktEl = this.$sellecktEl = $(rendered).addClass('closed');
 
-        this.$items = $sellecktEl.find('.'+this.itemsClass);
-
         $originalSelectEl.hide().before($sellecktEl);
-
-        this.$scrollingParent = getScrollingParent($sellecktEl);
-
-        this.$overflowHiddenParent = getOverflowHiddenParent($sellecktEl);
 
         this.bindEvents();
 
         this._observeMutations($originalSelectEl[0]);
-
-        this.hideSelectionFromChoices();
     },
 
     destroy: function(){
@@ -687,92 +491,15 @@ _.extend(SingleSelleckt.prototype, {
             return;
         }
 
+        this._removePopup();
+
         this._stopObservingMutations();
 
         $(document).off('click.selleckt-' + this.id);
-        this.$scrollingParent.off('scroll.selleckt-' + this.id);
 
         this.$sellecktEl.off().remove();
         this.$originalSelectEl.off('change.selleckt');
         this.$originalSelectEl.removeData('selleckt').show();
-    },
-
-    _findMatchingOptions: function(items, term){
-        return _(items).map(function(item){
-
-            if (!item.value) {
-                return item;
-            }
-
-            var matchIndex = item.label.toLowerCase().indexOf(term);
-
-            if(matchIndex === -1){
-                return item;
-            }
-
-            return (_.extend({}, item, {
-                matchStart: matchIndex,
-                matchEnd: matchIndex + (term.length - 1)
-            }));
-        });
-    },
-
-    clearSearch: function(){
-        var $searchInput = this.$sellecktEl.find('.' + this.searchInputClass);
-
-        if(!$searchInput.length){
-            return;
-        }
-
-        $searchInput.val('');
-        this.filterOptions('');
-    },
-
-    filterOptions: function(term){
-        var items = this.items,
-            matches = this._findMatchingOptions(items, term.toLowerCase()),
-            selectedItems = [].concat(this.getSelection()),
-            selectedIndices = _(selectedItems).reduce(function(memo, item){
-                var idx = _(items).indexOf(item);
-                if(idx !== -1){
-                    memo.push(idx);
-                }
-                return memo;
-            }, []),
-            $theItems = this.$items.find('.' + this.itemClass),
-            textClass = '.' + this.itemTextClass,
-            markStart = '<mark>',
-            markEnd = '</mark>';
-
-        _(matches).each(function(item, index){
-            var $item = $theItems.eq(index),
-                $textContainer = $item.find(textClass),
-                isSelectedItem = _(selectedIndices).contains(index),
-                html;
-
-            if(!_.isNumber(item.matchStart)){
-                $textContainer.html(item.label);
-                $item.hide();
-
-                return;
-            }
-
-            html = _.escape(item.label.substring(0, item.matchStart)) +
-                    markStart +
-                    _.escape(item.label.slice(item.matchStart, item.matchEnd + 1)) +
-                    markEnd +
-                    _.escape(item.label.substring(item.matchEnd + 1));
-
-            $textContainer.html(html);
-
-            if(!isSelectedItem){
-                $item.show();
-            }
-        });
-
-        this.$sellecktEl.toggleClass('noitems', !this.$items.find('mark').length);
-
-        this.trigger('optionsFiltered', term);
     }
 });
 

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -180,9 +180,13 @@ _.extend(SingleSelleckt.prototype, {
     },
 
     _filterItems: function(items, term){
+        var matchTerm;
+
         if(!term){
             return items;
         }
+
+        matchTerm = term.toLowerCase();
 
         return _.reduce(items, function(memo, item){
             var matchIndex;
@@ -191,7 +195,7 @@ _.extend(SingleSelleckt.prototype, {
                 return memo;
             }
 
-            matchIndex = item.label.toLowerCase().indexOf(term);
+            matchIndex = item.label.toLowerCase().indexOf(matchTerm);
 
             if(matchIndex === -1){
                 return memo;

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -148,7 +148,13 @@ _.extend(SingleSelleckt.prototype, {
             showSearch: this.showSearch
         });
 
-        popup.open(this.$sellecktEl, this.getItemsForPopup());
+        var popupOptions = {
+            css: {
+                minWidth: this.$sellecktEl.outerWidth() + 'px'
+            }
+        };
+
+        popup.open(this.$sellecktEl.find('.'+this.selectedClass), this.getItemsForPopup(), popupOptions);
 
         popup.bind('close', _.bind(this._onPopupClose, this));
         popup.bind('valueSelected', _.bind(this._onPopupValueSelected, this));

--- a/lib/TEMPLATES.js
+++ b/lib/TEMPLATES.js
@@ -6,19 +6,6 @@ var TEMPLATES = {
             '<div class="{{selectedClass}}">' +
                 '<span class="{{selectedTextClass}}">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
             '</div>' +
-            '<div class="{{itemsClass}}">' +
-                '{{#showSearch}}' +
-                '<div class="searchContainer">' +
-                    '<input class="{{searchInputClass}}"></input>' +
-                '</div>' +
-                '<span class="noitemsText">No items</span>' +
-                '{{/showSearch}}' +
-                '<ul class="{{itemslistClass}}">' +
-                    '{{#items}}' +
-                        '{{> item}}' +
-                    '{{/items}}' +
-                '</ul>' +
-            '</div>' +
         '</div>',
     SINGLE_ITEM:
         '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
@@ -33,13 +20,6 @@ var TEMPLATES = {
             '<div class="{{selectedClass}}">' +
                 '<span class="{{selectedTextClass}}">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
             '</div>' +
-            '<div class="{{itemsClass}}">' +
-                '<ul class="{{itemslistClass}}">' +
-                '{{#items}}' +
-                    '{{> item}}' +
-                '{{/items}}' +
-                '</ul>' +
-            '</div>' +
         '</div>',
     MULTI_ITEM:
         '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
@@ -48,7 +28,21 @@ var TEMPLATES = {
     MULTI_SELECTION:
         '<li class="{{selectionItemClass}}" data-value="{{value}}">' +
             '{{text}}<i class="icon-remove {{unselectItemClass}}"></i>' +
-        '</li>'
+        '</li>',
+    ITEMS_CONTAINER:
+        '<div class="{{itemsClass}}">' +
+            '{{#showSearch}}' +
+            '<div class="searchContainer">' +
+                '<input class="{{searchInputClass}}"></input>' +
+            '</div>' +
+            '<span class="noitemsText">No items</span>' +
+            '{{/showSearch}}' +
+            '<ul class="{{itemslistClass}}">' +
+                '{{#items}}' +
+                    '{{> item}}' +
+                '{{/items}}' +
+            '</ul>' +
+        '</div>'
 };
 
 module.exports = TEMPLATES;

--- a/lib/selleckt.js
+++ b/lib/selleckt.js
@@ -2,6 +2,7 @@
 
 var SingleSelleckt = require('./SingleSelleckt');
 var MultiSelleckt = require('./MultiSelleckt');
+var SellecktPopup = require('./SellecktPopup');
 var templateUtils = require('./templateUtils');
 var jqueryPlugin = require('./sellecktJqueryPlugin');
 
@@ -17,6 +18,7 @@ var selleckt = {
     },
     SingleSelleckt: SingleSelleckt,
     MultiSelleckt: MultiSelleckt,
+    SellecktPopup: SellecktPopup,
     templateUtils: templateUtils
 };
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -27,7 +27,9 @@
     "predef": [
         "require",
         "describe",
+        "before",
         "beforeEach",
+        "after",
         "afterEach",
         "it",
         "expect",

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -522,7 +522,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                 popup.open($opener, items);
 
                 expect(focusStub.calledOnce).toEqual(true);
-                expect(focusStub.thisValues[0].is(popup.$popup.find(popup.itemClass).eq(0)));
+                expect(focusStub.thisValues[0].is(popup.$popup.find('.' + popup.itemClass).eq(0))).toEqual(true);
             });
 
             it('renders the items into the popup', function(){

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -1,0 +1,871 @@
+'use strict';
+
+function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
+
+    var template =
+        '<div class="{{itemsClass}}">' +
+            '{{#showSearch}}' +
+            '<div class="searchContainer">' +
+                '<input class="{{searchInputClass}}"></input>' +
+            '</div>' +
+            '<span class="noitemsText">No items</span>' +
+            '{{/showSearch}}' +
+            '<ul class="{{itemslistClass}}">' +
+                '{{#items}}' +
+                    '{{> item}}' +
+                '{{/items}}' +
+            '</ul>' +
+        '</div>';
+
+    var itemTemplate =
+        '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+            '<span class="{{itemTextClass}}">{{label}}</span>' +
+        '</li>';
+
+    var KEY_CODES = {
+        DOWN: 40,
+        UP: 38,
+        ENTER: 13,
+        ESC: 27
+    };
+
+    return describe('SellecktPopup', function(){
+        var popup;
+        var sandbox = sinon.sandbox.create();
+
+        afterEach(function(){
+            if(popup){
+                popup.close();
+                popup = undefined;
+            }
+
+            sandbox.restore();
+        });
+
+        describe('valid instantation with custom options', function(){
+            var popupOptions;
+
+            beforeEach(function(){
+                popupOptions = {
+                    template: template,
+                    itemTemplate: itemTemplate,
+                    itemsClass: 'myItemsClass',
+                    itemslistClass: 'myItemsListClass',
+                    itemClass: 'myItemClass',
+                    itemTextClass: 'myItemTextClass',
+                    highlightClass: 'myHighlightClass',
+                    searchInputClass: 'mySearchInputClass',
+                    showSearch: true,
+                    templateData: {foo: 'bar'}
+                };
+
+                popup = new SellecktPopup(popupOptions);
+            });
+
+            it('stores the template as this.template', function(){
+                expect(popup.template).toEqual(template);
+            });
+
+            it('stores the itemTemplate as this.itemTemplate', function(){
+                expect(popup.itemTemplate).toEqual(itemTemplate);
+            });
+
+            it('stores the itemsClass passed in as this.itemsClass', function(){
+                expect(popup.itemsClass).toEqual(popupOptions.itemsClass);
+            });
+
+            it('stores the itemslistClass passed in as this.itemslistClass', function(){
+                expect(popup.itemslistClass).toEqual(popupOptions.itemslistClass);
+            });
+
+            it('stores the itemClass passed in as this.itemClass', function(){
+                expect(popup.itemClass).toEqual(popupOptions.itemClass);
+            });
+
+            it('stores the itemTextClass passed in as this.itemTextClass', function(){
+                expect(popup.itemTextClass).toEqual(popupOptions.itemTextClass);
+            });
+
+            it('stores the highlightClass passed in as this.highlightClass', function(){
+                expect(popup.highlightClass).toEqual(popupOptions.highlightClass);
+            });
+
+            it('stores the searchInputClass passed in as this.searchInputClass', function(){
+                expect(popup.searchInputClass).toEqual(popupOptions.searchInputClass);
+            });
+
+            it('stores the showSearch passed in as this.showSearch', function(){
+                expect(popup.showSearch).toEqual(popupOptions.showSearch);
+            });
+
+            it('stores the templateData passed in as this.templateData', function(){
+                expect(popup.templateData).toEqual(popupOptions.templateData);
+            });
+        });
+
+        describe('valid instantation with default options', function(){
+            beforeEach(function(){
+                popup = new SellecktPopup();
+            });
+
+            it('stores the template as this.template', function(){
+                expect(popup.template).toEqual(template);
+            });
+
+            it('stores the itemTemplate as this.itemTemplate', function(){
+                expect(popup.itemTemplate).toEqual(itemTemplate);
+            });
+
+            it('uses "items" as this.itemsClass', function(){
+                expect(popup.itemsClass).toEqual('items');
+            });
+
+            it('uses "itemslist" as this.itemslistClass', function(){
+                expect(popup.itemslistClass).toEqual('itemslist');
+            });
+
+            it('uses "item" as this.itemClass', function(){
+                expect(popup.itemClass).toEqual('item');
+            });
+
+            it('uses "itemText" as this.itemTextClass', function(){
+                expect(popup.itemTextClass).toEqual('itemText');
+            });
+
+            it('uses "highlighted" as this.highlightClass', function(){
+                expect(popup.highlightClass).toEqual('highlighted');
+            });
+
+            it('uses "search" as this.searchInputClass', function(){
+                expect(popup.searchInputClass).toEqual('search');
+            });
+
+            it('this.showSearch should be false', function(){
+                expect(popup.showSearch).toEqual(false);
+            });
+
+            it('stores an empty object as this.templateData', function(){
+                expect(popup.templateData).toEqual({});
+            });
+        });
+
+        describe('template caching', function (){
+            var cacheStub;
+
+            beforeEach(function(){
+                cacheStub = sinon.stub(templateUtils, 'cacheTemplate');
+                popup = new SellecktPopup();
+            });
+
+            afterEach(function(){
+                cacheStub.restore();
+            });
+
+            it('caches the main template', function(){
+                expect(cacheStub.calledWith(template)).toEqual(true);
+            });
+
+            it('caches the item template', function(){
+                expect(cacheStub.calledWith(itemTemplate)).toEqual(true);
+            });
+        });
+
+        describe('rendering items', function (){
+            var items;
+            var mustacheRenderSpy;
+
+            beforeEach(function(){
+                items = [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3},
+                    {label: 'item 4', value: 4},
+                    {label: 'item 5', value: 5}
+                ];
+
+                popup = new SellecktPopup();
+                popup.$popup = $('<div>');
+
+                mustacheRenderSpy = sandbox.spy(Mustache, 'render');
+
+                popup.renderItems(items);
+            });
+
+            it('replaces the popup contents with the rendered template', function(){
+                var itemSelector = '.'+popup.itemClass;
+                var itemTextSelector = '.'+popup.itemTextClass;
+                var itemContainerSelector = '.'+popup.itemsClass;
+
+                expect(popup.$popup.children().length).toEqual(1);
+                expect(popup.$popup.children().eq(0).is(itemContainerSelector)).toEqual(true);
+
+                var $items = popup.$popup.find(itemSelector);
+
+                expect($items.length).toEqual(5);
+
+                expect($items.eq(0).attr('data-text')).toEqual('item 1');
+                expect($items.eq(0).attr('data-value')).toEqual('1');
+                expect($items.eq(0).find(itemTextSelector).text()).toEqual('item 1');
+
+                expect($items.eq(1).attr('data-text')).toEqual('item 2');
+                expect($items.eq(1).attr('data-value')).toEqual('2');
+                expect($items.eq(1).find(itemTextSelector).text()).toEqual('item 2');
+
+                expect($items.eq(2).attr('data-text')).toEqual('item 3');
+                expect($items.eq(2).attr('data-value')).toEqual('3');
+                expect($items.eq(2).find(itemTextSelector).text()).toEqual('item 3');
+
+                expect($items.eq(3).attr('data-text')).toEqual('item 4');
+                expect($items.eq(3).attr('data-value')).toEqual('4');
+                expect($items.eq(3).find(itemTextSelector).text()).toEqual('item 4');
+
+                expect($items.eq(4).attr('data-text')).toEqual('item 5');
+                expect($items.eq(4).attr('data-value')).toEqual('5');
+                expect($items.eq(4).find(itemTextSelector).text()).toEqual('item 5');
+            });
+
+            it('renders using this.template', function(){
+                expect(mustacheRenderSpy.args[0][0]).toEqual(popup.template);
+            });
+
+            it('passes the value of this.showSearch to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].showSearch).toEqual(popup.showSearch);
+            });
+            it('passes the value of this.itemsClass to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].itemsClass).toEqual(popup.itemsClass);
+            });
+            it('passes the value of this.itemslistClass to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].itemslistClass).toEqual(popup.itemslistClass);
+            });
+            it('passes the value of this.itemClass to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].itemClass).toEqual(popup.itemClass);
+            });
+            it('passes the value of this.itemTextClass to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].itemTextClass).toEqual(popup.itemTextClass);
+            });
+            it('passes the value of this.searchInputClass to the template', function(){
+                expect(mustacheRenderSpy.args[0][1].searchInputClass).toEqual(popup.searchInputClass);
+            });
+
+            it('renders using this.itemTemplate as a partial', function(){
+                expect(mustacheRenderSpy.args[0][2]).toEqual({
+                    item: popup.itemTemplate
+                });
+            });
+        });
+
+        describe('refreshing items', function (){
+            var newItems;
+            var mustacheRenderSpy;
+
+            beforeEach(function(){
+                newItems = [
+                    {label: 'new item 1', value: 10},
+                    {label: 'new item 2', value: 20},
+                ];
+
+                popup = new SellecktPopup();
+                popup.$popup = $('<div>');
+
+                popup.renderItems([
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3},
+                    {label: 'item 4', value: 4},
+                    {label: 'item 5', value: 5}
+                ]);
+
+                mustacheRenderSpy = sandbox.spy(Mustache, 'render');
+            });
+
+            it('replaces only the contents of the itemslist', function(){
+                var itemSelector = '.'+popup.itemClass;
+
+                $('<p>', {
+                    'class': 'leave-me-alone'
+                })
+                .text('bar')
+                .appendTo(popup.$popup);
+
+                expect(popup.$popup.find(itemSelector).length).toEqual(5);
+
+                popup.refreshItems(newItems);
+
+                expect(popup.$popup.find('.leave-me-alone').text()).toEqual('bar');
+                expect(popup.$popup.find(itemSelector).length).toEqual(2);
+            });
+
+            it('renders each item using this.itemTemplate', function(){
+                popup.refreshItems(newItems);
+
+                expect(mustacheRenderSpy.callCount).toEqual(2);
+            });
+
+            it('passes the value of this.itemTextClass to the item template', function(){
+                popup.refreshItems(newItems);
+
+                expect(mustacheRenderSpy.args[0][1].itemTextClass).toEqual(popup.itemTextClass);
+                expect(mustacheRenderSpy.args[1][1].itemTextClass).toEqual(popup.itemTextClass);
+            });
+            it('passes the value of this.itemClass to the item template', function(){
+                popup.refreshItems(newItems);
+
+                expect(mustacheRenderSpy.args[0][1].itemClass).toEqual(popup.itemClass);
+                expect(mustacheRenderSpy.args[1][1].itemClass).toEqual(popup.itemClass);
+            });
+            it('passes item.label to the item template', function(){
+                popup.refreshItems(newItems);
+
+                expect(mustacheRenderSpy.args[0][1].label).toEqual(newItems[0].label);
+                expect(mustacheRenderSpy.args[1][1].label).toEqual(newItems[1].label);
+            });
+            it('passes item.value to the item template', function(){
+                popup.refreshItems(newItems);
+
+                expect(mustacheRenderSpy.args[0][1].value).toEqual(newItems[0].value);
+                expect(mustacheRenderSpy.args[1][1].value).toEqual(newItems[1].value);
+            });
+
+            it('adds a "noitems" class to the popup if there are no items', function(){
+                popup.refreshItems([]);
+
+                expect(popup.$popup.hasClass('noitems')).toEqual(true);
+            });
+
+            describe('marking items', function(){
+                var addMarkSpy;
+
+                beforeEach(function(){
+                    addMarkSpy = sandbox.spy(popup, '_addMarkToItem');
+                });
+
+                it('does not add a mark to the item if the item has a negative integer value for "matchEnd"', function(){
+                    var refreshItems = [{
+                        label: 'new item 1',
+                        value: 10,
+                        matchStart: 0,
+                        matchEnd: -1
+                    }];
+
+                    popup.refreshItems(refreshItems);
+
+                    expect(addMarkSpy.called).toEqual(false);
+                });
+
+                it('does not add a mark to the item if the item has a falsey "matchEnd"', function(){
+                    var refreshItems = [{
+                        label: 'new item 1',
+                        value: 10,
+                        matchStart: 0,
+                        matchEnd: -1
+                    }];
+
+                    popup.refreshItems(refreshItems);
+
+                    expect(addMarkSpy.called).toEqual(false);
+                });
+
+                it('adds a mark to the item if the item has a positive integer value for "matchEnd"', function(){
+                    var refreshItems = [{
+                        label: 'new item 1',
+                        value: 10,
+                        matchStart: 0,
+                        matchEnd: 2
+                    }];
+
+                    popup.refreshItems(refreshItems);
+
+                    expect(addMarkSpy.calledOnce).toEqual(true);
+                });
+
+                it('escapes the substrings, based on the item.matchStart and item.matchEnd', function(){
+                    var refreshItems = [{
+                        label: 'new item 1',
+                        value: 10,
+                        matchStart: 4,
+                        matchEnd: 7
+                    }];
+
+                    var escapeSpy = sandbox.spy(_, 'escape');
+
+                    popup.refreshItems(refreshItems);
+
+                    expect(addMarkSpy.calledOnce).toEqual(true);
+
+                    var itemSelector = '.'+popup.itemClass;
+
+                    var $items = popup.$popup.find(itemSelector);
+
+                    expect($items.length).toEqual(1);
+                    expect($items.eq(0).text()).toEqual('new item 1');
+
+                    expect($items.find('mark').length).toEqual(1);
+                    expect($items.find('mark').text()).toEqual('item');
+
+                    expect(escapeSpy.callCount).toEqual(3);
+                    expect(escapeSpy.args[0][0]).toEqual('new ');
+                    expect(escapeSpy.args[1][0]).toEqual('item');
+                    expect(escapeSpy.args[2][0]).toEqual(' 1');
+                });
+
+                it('wraps the matched text in a <mark>', function(){
+                    var refreshItems = [{
+                        label: 'new item 1',
+                        value: 10,
+                        matchStart: 0,
+                        matchEnd: 2
+                    }];
+
+                    popup.refreshItems(refreshItems);
+
+                    expect(addMarkSpy.calledOnce).toEqual(true);
+
+                    var itemSelector = '.'+popup.itemClass;
+
+                    var $items = popup.$popup.find(itemSelector);
+
+                    expect($items.length).toEqual(1);
+                    expect($items.eq(0).text()).toEqual('new item 1');
+                    expect($items.find('mark').length).toEqual(1);
+                    expect($items.find('mark').text()).toEqual('new');
+                });
+            });
+        });
+
+        describe('opening the popup', function (){
+            var bindEventsStub;
+            var positionStub;
+            var items;
+            var $opener;
+            var offsetStub;
+            var renderItemsSpy;
+
+            beforeEach(function(){
+                bindEventsStub = sandbox.stub(SellecktPopup.prototype, 'bindEvents');
+                positionStub = sandbox.stub(SellecktPopup.prototype, '_positionPopup');
+                renderItemsSpy = sandbox.spy(SellecktPopup.prototype, 'renderItems');
+
+                items = [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3},
+                    {label: 'item 4', value: 4},
+                    {label: 'item 5', value: 5},
+                ];
+
+                $opener = $('<div>foo</div>', {
+                    'class': 'opener'
+                });
+
+                offsetStub = sandbox.stub($opener, 'offset').returns({
+                    top: 50,
+                    left: 100
+                });
+            });
+
+            afterEach(function(){
+                $opener.remove();
+            });
+
+            it('creates a handler for window.resize and adds it as this.resizeHandler', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                expect(typeof popup.resizeHandler).toEqual('function');
+
+                positionStub.reset();
+
+                $(window).trigger('resize');
+
+                expect(positionStub.callCount).toEqual(1);
+            });
+
+            it('creates a div with "selleckt" and "sellecktPopup" classes', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                var $popup = popup.$popup;
+
+                expect($popup).toBeDefined();
+                expect($popup.hasClass('selleckt')).toEqual(true);
+                expect($popup.hasClass('sellecktPopup')).toEqual(true);
+            });
+
+            it('attaches the popup to the document body', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                var $popup = popup.$popup;
+
+                expect($popup.parent().is('body')).toEqual(true);
+            });
+
+            it('positions the popup based on the offset of the opener element', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                expect(positionStub.calledOnce).toEqual(true);
+                expect(positionStub.args[0][0]).toEqual($opener);
+            });
+
+            it('focuses the searchInput if showSearch is true', function(){
+                popup = new SellecktPopup({showSearch: true});
+                popup.open($opener, items);
+
+                expect($(document.activeElement).hasClass(popup.searchInputClass)).toEqual(true);
+            });
+
+            it('focuses the first item if showSearch is false', function(){
+                var focusStub = sandbox.stub($.fn, 'focus');
+
+                popup = new SellecktPopup({showSearch: false});
+                popup.open($opener, items);
+
+                expect(focusStub.calledOnce).toEqual(true);
+                expect(focusStub.thisValues[0].is(popup.$popup.find(popup.itemClass).eq(0)));
+            });
+
+            it('renders the items into the popup', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                expect(renderItemsSpy.calledOnce).toEqual(true);
+                expect(renderItemsSpy.calledWith(items)).toEqual(true);
+            });
+
+            it('calls this.bindEvents', function(){
+                popup = new SellecktPopup();
+                popup.open($opener, items);
+
+                expect(bindEventsStub.calledOnce).toEqual(true);
+            });
+        });
+
+        describe('closing the popup', function (){
+            var $body;
+
+            beforeEach(function(){
+                $body = $('body');
+
+                popup = new SellecktPopup();
+                popup.$popup = $('<div class="popup">').appendTo($body);
+            });
+
+            it('removes popup.resizeHandler', function(){
+                popup._attachResizeHandler($('<div>'));
+                expect(typeof popup.resizeHandler).toEqual('function');
+
+                popup.close();
+                expect(typeof popup.resizeHandler).toEqual('undefined');
+            });
+
+            it('removes the popup from the DOM', function(){
+                expect($body.find('.popup').length).toEqual(1);
+
+                popup.close();
+
+                expect($body.find('.popup').length).toEqual(0);
+            });
+
+            it('sets this.$popup to undefined', function(){
+                popup.close();
+                expect(popup.$popup).toBeUndefined();
+            });
+
+            it('triggers a close event', function(){
+                var spy = sandbox.spy();
+
+                popup.bind('close', spy);
+                popup.close();
+
+                expect(spy.calledOnce).toEqual(true);
+            });
+        });
+
+        //these tests manipulate the DOM so they can test the layout of the popup.
+        describe('positioning the popup [DOM tests]', function (){
+            var $opener;
+            var items;
+            var _OPENER_LEFT;
+
+            beforeEach(function (){
+                _OPENER_LEFT = 100;
+
+                $opener = $('<div>', {
+                    'class': opener,
+                    'css': {
+                        position: 'absolute',
+                        left: _OPENER_LEFT
+                    }
+                }).appendTo($('body'));
+
+                items = [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3},
+                    {label: 'item 4', value: 4},
+                    {label: 'item 5', value: 5},
+                ];
+
+                popup = new SellecktPopup();
+            });
+
+            afterEach(function (){
+                $opener.remove();
+            });
+
+            it('sets the css "position" property to "absolute"', function(){
+                popup.open($opener, items);
+
+                expect(popup.$popup.css('position')).toEqual('absolute');
+
+            });
+            it('sets the css "left" position to that of the popup opener', function(){
+                popup.open($opener, items);
+
+                expect(popup.$popup.css('left')).toEqual(_OPENER_LEFT + 'px');
+            });
+
+            it('does not set a css class of "flipped" if there is enough room below the opener', function(){
+                $opener.css({top: 0});
+
+                popup.open($opener, items);
+
+                expect(popup.$popup.hasClass('flipped')).toEqual(false);
+            });
+
+            it('sets a css class of "flipped" if there is not enough room below the opener', function(){
+                $opener.css({top: $(window).height()});
+
+                popup.open($opener, items);
+
+                expect(popup.$popup.hasClass('flipped')).toEqual(true);
+            });
+        });
+
+        describe('Keyboard input - items', function(){
+            var $opener;
+            var $popup;
+            var items;
+
+            beforeEach(function(){
+                items = [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3}
+                ];
+
+                popup = new SellecktPopup({
+                    showSearch: false
+                });
+
+                $opener = $('<div>', {
+                    'class': opener
+                }).appendTo($('body'));
+
+                popup.open($opener, items);
+
+                $popup = popup.$popup;
+            });
+
+            afterEach(function(){
+                $opener.remove();
+            });
+
+            it('closes the popup when esc is pressed', function(){
+                var closeSpy = sandbox.spy(popup, 'close');
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.ESC }));
+
+                expect(closeSpy.calledOnce).toEqual(true);
+            });
+
+            it('selects the current item when enter is pressed', function(){
+                var spy = sandbox.spy();
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+
+                popup.bind('valueSelected', spy);
+
+                $firstItem.addClass(popup.highlightClass);
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
+
+                expect(spy.calledOnce).toEqual(true);
+                expect(spy.args[0][0]).toEqual($firstItem.attr('data-value'));
+            });
+
+            it('closes the popup when enter is pressed', function(){
+                var closeSpy = sandbox.spy(popup, 'close');
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+
+                $firstItem.addClass(popup.highlightClass);
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
+
+                expect(closeSpy.calledOnce).toEqual(true);
+            });
+
+            it('highlights the next item if there is one when down is pressed', function(){
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+                var $secondItem = $firstItem.next();
+
+                $firstItem.addClass(popup.highlightClass);
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+
+                expect($secondItem.hasClass(popup.highlightClass)).toEqual(true);
+            });
+
+            it('highlights the first item if there is no next item when down is pressed', function(){
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+                $firstItem.addClass(popup.highlightClass);
+
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+
+                expect($firstItem.hasClass(popup.highlightClass)).toEqual(true);
+            });
+
+            it('highlights the previous item when up is pressed', function(){
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+                $firstItem.addClass(popup.highlightClass);
+
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+                $firstItem.trigger($.Event('keydown', { which : KEY_CODES.UP }));
+
+                expect($firstItem.hasClass(popup.highlightClass)).toEqual(true);
+            });
+        });
+
+        describe('Keyboard input - search', function(){
+            var $opener;
+            var $popup;
+            var $searchInput;
+            var items;
+
+            beforeEach(function(){
+                sandbox.stub(_, 'debounce', function(func){ return func; });
+
+                items = [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3}
+                ];
+
+                popup = new SellecktPopup({
+                    showSearch: true
+                });
+
+                $opener = $('<div>', {
+                    'class': opener
+                }).appendTo($('body'));
+
+                popup.open($opener, items);
+
+                $popup = popup.$popup;
+
+                $searchInput = $popup.find('.' + popup.searchInputClass);
+                $searchInput.focus();
+            });
+
+            afterEach(function(){
+                $opener.remove();
+            });
+
+            it('closes the popup when esc is pressed', function(){
+                var closeSpy = sandbox.spy(popup, 'close');
+
+                $searchInput.trigger($.Event('keydown', { which : KEY_CODES.ESC }));
+
+                expect(closeSpy.calledOnce).toEqual(true);
+            });
+
+            it('selects the first item when down is pressed', function(){
+                var $firstItem = $popup.find('.'+popup.itemClass).first();
+
+                expect($firstItem.hasClass(popup.highlightClass)).toEqual(false);
+
+                $searchInput.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
+
+                expect($firstItem.hasClass(popup.highlightClass)).toEqual(true);
+            });
+
+            it('triggers a "search" event with the current term when enter is pressed', function(){
+                var searchSpy = sandbox.spy();
+                var letterCodes = {
+                    O: 79
+                };
+
+                popup.bind('search', searchSpy);
+
+                $searchInput.val('foo');
+                $searchInput.trigger($.Event('keyup', { which : letterCodes.O }));
+
+                expect(searchSpy.calledOnce).toEqual(true);
+                expect(searchSpy.args[0][0]).toEqual($searchInput.val());
+            });
+        });
+
+        describe('Mouse events', function(){
+            it('highlights the current item and de-highlights all other items on mouseover', function(){
+                var $opener = $('<div>foo</div>', {
+                    'class': 'opener'
+                });
+
+                popup = new SellecktPopup();
+
+                popup.open($opener, [
+                    {label: 'item 1', value: 1},
+                    {label: 'item 2', value: 2},
+                    {label: 'item 3', value: 3},
+                    {label: 'item 4', value: 4},
+                    {label: 'item 5', value: 5},
+                ]);
+
+                var highlightClass = popup.highlightClass,
+                    liOne = popup.$popup.find('li.item').eq(0),
+                    liTwo = popup.$popup.find('li.item').eq(1);
+
+                expect(liTwo.hasClass(highlightClass)).toEqual(false);
+
+                liOne.trigger('mouseover');
+                expect(liOne.hasClass(highlightClass)).toEqual(true);
+
+                liOne.trigger('mouseout');
+                expect(liOne.hasClass(highlightClass)).toEqual(true);
+
+                liTwo.trigger('mouseover');
+                expect(liOne.hasClass(highlightClass)).toEqual(false);
+                expect(liTwo.hasClass(highlightClass)).toEqual(true);
+            });
+        });
+    });
+}
+
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like enviroments that support module.exports,
+        // like Node.
+        var selleckt = require('../../lib/selleckt');
+
+        factory(exports = sellecktPopupSpecs,
+                selleckt.SellecktPopup,
+                selleckt.templateUtils,
+                require('jquery'),
+                require('underscore'),
+                require('Mustache')
+            );
+    } else {
+        // Browser globals
+        factory(
+            root.singleSellecktSpecs,
+            root.selleckt.SellecktPopup,
+            root.selleckt.templateUtils,
+            root.$,
+            root._,
+            root.Mustache
+        );
+    }
+}(this, function (exports, SellecktPopup, templateUtils, $, _, Mustache) {
+    return sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache);
+}));

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -206,6 +206,29 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                             data: {}
                         });
                     });
+                    it('ignores empty options', function(){
+                        var selectHtml = '<select>' +
+                            '<option></option>' +
+                            '<option value="2">bar</option>' +
+                            '<option value="3">baz</option>' +
+                            '</select>';
+
+                        selleckt.destroy();
+
+                        var $newEl = $(selectHtml).appendTo($testArea);
+
+                        selleckt = new SingleSelleckt({
+                            $selectEl : $newEl
+                        });
+
+                        expect(selleckt.items.length).toEqual(2);
+
+                        expect(selleckt.items[0].value).toEqual('2');
+                        expect(selleckt.items[0].label).toEqual('bar');
+
+                        expect(selleckt.items[1].value).toEqual('3');
+                        expect(selleckt.items[1].label).toEqual('baz');
+                    });
 
                     describe('when there is no selected item already', function(){
                         var $newEl;

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -1113,6 +1113,28 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 ]);
             });
 
+            it('performs a case-insensitive search', function(){
+                var selleckt = new SingleSelleckt({
+                    $selectEl: $('<select>')
+                });
+
+                selleckt.items = [
+                    {label: 'foo', value: 'foo'},
+                    {label: 'bar', value: 'bar'},
+                    {label: 'baz', value: 'baz'},
+                    {label: 'foofoo', value: 'foofoo'},
+                    {label: 'foobaz', value: 'foobaz'}
+                ];
+
+                var filteredItems = selleckt._filterItems(selleckt.items, 'BA');
+
+                expect(filteredItems).toEqual([
+                    { label: 'bar', value: 'bar', matchStart: 0, matchEnd: 1 },
+                    { label: 'baz', value: 'baz', matchStart: 0, matchEnd: 1 },
+                    { label: 'foobaz', value: 'foobaz', matchStart: 3, matchEnd: 4 }
+                ]);
+            });
+
             it('triggers an "optionsFiltered" event after filtering, passing the filter term', function(){
                 var spy = sandbox.spy();
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -785,6 +785,20 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 selleckt._close();
             });
 
+            it('allows an item to be selected by value', function(){
+                var dummyItem = {value: 100};
+                var options = {foo: 'bar'};
+                var selectItemStub = sandbox.stub(SingleSelleckt.prototype, 'selectItem');
+
+                sandbox.stub(SingleSelleckt.prototype, 'findItem').returns(dummyItem);
+
+                selleckt.selectItemByValue(100, options);
+
+                expect(selectItemStub.calledOnce).toEqual(true);
+                expect(selectItemStub.args[0][0]).toEqual(dummyItem);
+                expect(selectItemStub.args[0][1]).toEqual(options);
+            });
+
             it('does not allow multiple items to be selected', function(){
                 popup.trigger('valueSelected', '2');
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -3,29 +3,30 @@
 function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
     return describe('SingleSelleckt', function(){
         var selleckt,
-            mainTemplate =
-                '<div class="{{className}}">' +
-                '<div class="selected">' +
-                    '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
-                '</div>' +
-                '<ul class="items">' +
-                    '{{#items}}' +
-                    '<li class="item{{#selected}} selected{{/selected}}" data-value="{{value}}">' +
-                        '{{label}}' +
-                    '</li>' +
-                    '{{/items}}' +
-                '</ul>' +
-                '</div>',
             elHtml =
                 '<select>' +
                     '<option selected value="1">foo</option>' +
                     '<option value="2" data-meh="whee" data-bah="oink">bar</option>' +
                     '<option value="3">baz</option>' +
                 '</select>',
-            $el;
+            $testArea,
+            $el,
+            sandbox;
+
+        before(function(){
+            sandbox = sinon.sandbox.create();
+
+            $testArea = $('<div>', {
+                'class': 'testArea',
+                css: {
+                    position: 'absolute',
+                    left: '-999px'
+                }
+            }).appendTo($('body'));
+        });
 
         beforeEach(function(){
-            $el = $(elHtml).appendTo('body');
+            $el = $(elHtml).appendTo($testArea);
         });
 
         afterEach(function(){
@@ -36,36 +37,19 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 selleckt.destroy();
                 selleckt = undefined;
             }
+
+            $testArea.empty();
+            sandbox.restore();
         });
 
         describe('Instantiation', function(){
-            var template =
-                '<div class="{{className}}" tabindex=1>' +
-                    '<div class="selected">' +
-                        '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
-                    '</div>' +
-                    '<ul class="items">' +
-                        '{{#showSearch}}' +
-                        '<li class="searchContainer">' +
-                            '<input class="search"></input>' +
-                        '</li>' +
-                        '{{/showSearch}}' +
-                        '{{#items}}' +
-                            '{{> item}}' +
-                        '{{/items}}' +
-                    '</ul>' +
-                '</div>',
-                itemTemplate = '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
-                    '<span class="{{itemTextClass}}">{{label}}</span>' +
-                '</li>';
-
             describe('invalid instantiation', function(){
                 it('pukes if instantiated with an invalid template format', function(){
                     var err;
 
                     try{
                         selleckt = new SingleSelleckt({
-                            mainTemplate : {template: template},
+                            mainTemplate : {template: '<div/>'},
                             $selectEl : $el,
                             className: 'selleckt',
                             selectedClass: 'selected',
@@ -86,11 +70,47 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             });
 
             describe('valid instantation', function(){
+                var template =
+                '<div class="{{className}}" tabindex=1>' +
+                    '<div class="selected">' +
+                        '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
+                    '</div>' +
+                    '<ul class="items">' +
+                        '{{#showSearch}}' +
+                        '<li class="searchContainer">' +
+                            '<input class="search"></input>' +
+                        '</li>' +
+                        '{{/showSearch}}' +
+                        '{{#items}}' +
+                            '{{> item}}' +
+                        '{{/items}}' +
+                    '</ul>' +
+                '</div>',
+                itemTemplate = '<li class="{{itemClass}}" data-text="{{label}}" data-value="{{value}}">' +
+                    '<span class="{{itemTextClass}}">{{label}}</span>' +
+                '</li>',
+                popupTemplate =
+                '<div class="{{itemsClass}}">' +
+                    '{{#showSearch}}' +
+                    '<div class="searchContainer">' +
+                        '<input class="{{searchInputClass}}"></input>' +
+                    '</div>' +
+                    '<span class="noitemsText">No items</span>' +
+                    '{{/showSearch}}' +
+                    '<ul class="{{itemslistClass}}">' +
+                        '{{#items}}' +
+                            '{{> item}}' +
+                        '{{/items}}' +
+                    '</ul>' +
+                '</div>';
 
                 beforeEach(function(){
                     selleckt = new SingleSelleckt({
                         mainTemplate: template,
                         itemTemplate: itemTemplate,
+                        popupTemplate: popupTemplate,
+                        mainTemplateData: {foo: 'bar'},
+                        popupTemplateData: {meh: 'boo'},
                         $selectEl : $el,
                         className: 'selleckt',
                         selectedClass: 'selected',
@@ -98,7 +118,8 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                         itemsClass: 'items',
                         itemClass: 'item',
                         selectedClassName: 'isSelected',
-                        highlightClass: 'isHighlighted'
+                        highlightClass: 'isHighlighted',
+                        hideSelectedItem: true
                     });
                 });
 
@@ -126,8 +147,16 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                     expect(selleckt.itemTemplate).toEqual(itemTemplate);
                 });
 
+                it('stores options.popupTemplate as this.popupTemplate', function(){
+                    expect(selleckt.popupTemplate).toEqual(popupTemplate);
+                });
+
                 it('stores options.mainTemplateData as this.mainTemplateData', function(){
-                    expect(selleckt.mainTemplateData).toEqual({});
+                    expect(selleckt.mainTemplateData).toEqual({foo: 'bar'});
+                });
+
+                it('stores options.popupTemplateData as this.popupTemplateData', function(){
+                    expect(selleckt.popupTemplateData).toEqual({meh: 'boo'});
                 });
 
                 it('stores options.selectEl as this.originalSelectEl', function(){
@@ -140,6 +169,10 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
                 it('stores options.highlightClass as this.highlightClass', function(){
                     expect(selleckt.highlightClass).toEqual('isHighlighted');
+                });
+
+                it('stores options.hideSelectedItem as this.hideSelectedItem', function(){
+                    expect(selleckt.hideSelectedItem).toEqual(true);
                 });
 
                 describe('items', function(){
@@ -186,7 +219,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
                             selleckt.destroy();
 
-                            $newEl = $(selectHtml).appendTo('body');
+                            $newEl = $(selectHtml).appendTo($testArea);
 
                             selleckt = new SingleSelleckt({
                                 mainTemplate: template,
@@ -239,10 +272,6 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                     it('caches the main template', function(){
                         expect(cacheStub.calledWith(template)).toEqual(true);
                     });
-
-                    it('caches the item template', function(){
-                        expect(cacheStub.calledWith(itemTemplate)).toEqual(true);
-                    });
                 });
 
                 describe('events', function(){
@@ -266,1390 +295,812 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                         $el.off('change', onChangeStub);
                     });
                 });
+            });
+        });
 
-                describe('template formats', function(){
-                    it('accepts template strings', function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $el,
-                            className: 'selleckt',
-                            selectedClass: 'selected',
-                            selectedTextClass: 'selectedText',
-                            itemsClass: 'items',
-                            itemClass: 'item',
-                            selectedClassName: 'isSelected',
-                            highlightClassName: 'isHighlighted'
-                        });
-                        selleckt.render();
-                        expect(selleckt.$sellecktEl.find('.items').length).toEqual(1);
-                        expect(selleckt.$sellecktEl.find('.items > .item').length).toEqual(3);
-                    });
+        describe('rendering', function(){
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
                 });
 
-                describe('template data', function(){
-                    it('can build template data object from custom data and plugin data', function(){
-                        var templateData;
-
-                        selleckt = new SingleSelleckt({
-                            $selectEl : $el,
-                            enableSearch: true,
-                            className: 'selleckt',
-                            mainTemplateData: {
-                                selectLabel: 'Please selleckt',
-                                required: false
-                            }
-                        });
-
-                        templateData = selleckt.getTemplateData();
-
-                        expect(templateData.showSearch).toEqual(true);
-                        expect(templateData.selectedItemText).toEqual('foo');
-                        expect(templateData.className).toEqual('selleckt');
-                        expect(templateData.items).toBeDefined();
-                        expect(templateData.items.length).toEqual(3);
-                        expect(templateData.selectLabel).toEqual('Please selleckt');
-                        expect(templateData.required).toEqual(false);
-                    });
-
-                    it('prevents custom data from overriding plugin data', function(){
-                        var templateData;
-
-                        selleckt = new SingleSelleckt({
-                            $selectEl : $el,
-                            mainTemplateData: {
-                                selectLabel: 'Please selleckt',
-                                required: false,
-                                showSearch: 'yes',
-                                items: []
-                            }
-                        });
-
-                        templateData = selleckt.getTemplateData();
-
-                        expect(templateData.selectLabel).toEqual('Please selleckt');
-                        expect(templateData.required).toEqual(false);
-                        expect(templateData.showSearch).toEqual(false);
-                        expect(templateData.items).toBeDefined();
-                        expect(templateData.items.length).toEqual(3);
-                    });
-                    it('includes user configurable class names in template data', function(){
-                        var templateData;
-
-                        selleckt = new SingleSelleckt({
-                            $selectEl: $el,
-                            className: 'sellecktTest',
-                            selectedClass: 'trigger',
-                            selectedTextClass: 'triggerText',
-                            itemsClass: 'dropdown',
-                            itemslistClass: 'options',
-                            itemClass: 'option',
-                            itemTextClass: 'optionText',
-                            searchInputClass: 'searchBox'
-                        });
-
-                        templateData = selleckt.getTemplateData();
-
-                        expect(templateData.className).toEqual('sellecktTest');
-                        expect(templateData.selectedClass).toEqual('trigger');
-                        expect(templateData.selectedTextClass).toEqual('triggerText');
-                        expect(templateData.itemsClass).toEqual('dropdown');
-                        expect(templateData.itemslistClass).toEqual('options');
-                        expect(templateData.itemClass).toEqual('option');
-                        expect(templateData.itemTextClass).toEqual('optionText');
-                        expect(templateData.searchInputClass).toEqual('searchBox');
-                    });
-                });
+                selleckt.render();
             });
 
-            describe('rendering', function(){
-                beforeEach(function(){
-                    selleckt = new SingleSelleckt({
-                        $selectEl : $el
-                    });
-
-                    selleckt.render();
-                });
-                it('renders the selected element based on this.template', function(){
-                    expect(selleckt.$sellecktEl.find('.selected').length).toEqual(1);
-                });
-                it('renders the selected text element based on this.template', function(){
-                    expect(selleckt.$sellecktEl.find('.selectedText').length).toEqual(1);
-                    expect(selleckt.$sellecktEl.find('.selectedText').text()).toEqual(selleckt.selectedItem.label);
-                });
-                it('renders the items correctly', function(){
-                    expect(selleckt.$sellecktEl.find('.itemslist').length).toEqual(1);
-                    expect(selleckt.$sellecktEl.find('.itemslist > .item').length).toEqual(3);
-                });
-                it('hides the original Select element', function(){
-                    expect(selleckt.$originalSelectEl.css('display')).toEqual('none');
-                });
-                it('adds a class of "closed" to the element', function(){
-                    expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
-                });
-                it('replaces custom template tags with template data', function(){
-                    var customTemplate =
-                        '<div class="{{className}}">' +
-                            '{{#selectLabel}}<label>{{selectLabel}}</label>{{/selectLabel}}' +
-                            '{{#required}}<span class="required">*</span>{{/required}}' +
-                            '<div class="selected">' +
-                                '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
-                            '</div>' +
-                            '<ul class="items">' +
-                                '{{#items}}' +
-                                '<li class="item{{#selected}} selected{{/selected}}" data-value="{{value}}">' +
-                                    '{{label}}' +
-                                '</li>' +
-                                '{{/items}}' +
-                            '</ul>' +
-                        '</div>';
-
-                    selleckt.destroy();
-                    selleckt = new SingleSelleckt({
-                        $selectEl : $el,
-                        mainTemplate: customTemplate,
-                        mainTemplateData: {
-                            selectLabel: 'Please selleckt',
-                            required: false
-                        }
-                    });
-                    selleckt.render();
-
-                    expect(selleckt.$sellecktEl.find('label').length).toEqual(1);
-                    expect(selleckt.$sellecktEl.find('label').text()).toEqual('Please selleckt');
-                    expect(selleckt.$sellecktEl.find('.required').length).toEqual(0);
-                });
-                it('can determine closest $scrollingParent in DOM', function(){
-                    selleckt.destroy();
-
-                    $('body').css('overflow-y', 'scroll');
-
-                    selleckt = new SingleSelleckt({
-                        mainTemplate : mainTemplate,
-                        $selectEl : $el
-                    });
-                    selleckt.render();
-
-                    expect(selleckt.$scrollingParent.length).toEqual(1);
-                    expect(selleckt.$scrollingParent.is('body')).toEqual(true);
-
-                    $('body').css('overflow-y', 'visible');
-                });
-                it('returns window as $scrollingParent if no other scrolling parent is in DOM', function(){
-                    expect(selleckt.$scrollingParent.length).toEqual(1);
-                    expect(selleckt.$scrollingParent).toEqual($(window));
-                });
-                it('can determine closest $overflowHiddenParent in DOM', function(){
-                    selleckt.destroy();
-
-                    $('body').css({
-                        'overflow-y': 'hidden',
-                        'max-height': '1000px'
-                    });
-
-                    selleckt = new SingleSelleckt({
-                        mainTemplate : mainTemplate,
-                        $selectEl : $el
-                    });
-                    selleckt.render();
-
-                    expect(selleckt.$overflowHiddenParent.length).toEqual(1);
-                    expect(selleckt.$overflowHiddenParent.is('body')).toEqual(true);
-
-                    $('body').css({
-                        'overflow-y': 'visible',
-                        'max-height': 'auto'
-                    });
-                });
-                it('returns "undefined" if no other $overflowHiddenParent is in DOM', function(){
-                    expect(selleckt.$overflowHiddenParent).toBeUndefined();
-                });
+            it('renders the selected element based on this.template', function(){
+                expect(selleckt.$sellecktEl.find('.selected').length).toEqual(1);
             });
 
-            describe('Adding items', function(){
-                var item;
-                var waitTime = 100;
-
-                beforeEach(function(){
-                    item = {
-                        label: 'new',
-                        value: 'new value'
-                    };
-
-                    selleckt = new SingleSelleckt({
-                        $selectEl : $el
-                    });
-
-                    selleckt.render();
-                });
-
-                afterEach(function(){
-                    selleckt.destroy();
-                    selleckt = undefined;
-                });
-
-                describe('using addItem to add a single item', function(){
-                    it('adds an item to this.items', function(){
-                        expect(selleckt.items.length).toEqual(3);
-
-                        selleckt.addItem(item);
-
-                        expect(selleckt.items.length).toEqual(4);
-                        expect(selleckt.items[3]).toEqual(item);
-                    });
-
-                    it('appends a new option to the original select', function(){
-                        var $originalSelectEl = selleckt.$originalSelectEl;
-
-                        expect($originalSelectEl.children().length).toEqual(3);
-
-                        selleckt.addItem(item);
-
-                        expect($originalSelectEl.children().length).toEqual(4);
-
-                        var newOption = $originalSelectEl.find('option').eq(3);
-
-                        expect(newOption.text()).toEqual('new');
-                        expect(newOption.val()).toEqual('new value');
-                    });
-
-                    it('appends a new item to the Selleckt element itself', function(done){
-                        var $sellecktEl = selleckt.$sellecktEl;
-                        var itemClass = '.' + selleckt.itemClass;
-
-                        expect($sellecktEl.find(itemClass).length).toEqual(3);
-
-                        selleckt.addItem(item);
-
-                        //because of the dom event
-                        setTimeout(function(){
-                            expect($sellecktEl.find(itemClass).length).toEqual(4);
-                            done();
-                        }, waitTime);
-                    });
-
-                    it('selects the new item when it is clicked', function(done){
-                        var $sellecktEl = selleckt.$sellecktEl;
-
-                        selleckt.addItem(item);
-
-                        setTimeout(function(){
-                            $sellecktEl.trigger('click');
-                            $sellecktEl.find('li.item').eq(3).trigger('mouseover').trigger('click');
-
-                            expect(selleckt.selectedItem.label).toEqual('new');
-                            expect(selleckt.selectedItem.value).toEqual('new value');
-
-                            var $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-
-                            expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new');
-
-                            done();
-                        }, waitTime);
-                    });
-
-                    describe('and the new item has selected:true', function(){
-                        var originalSelection;
-
-                        beforeEach(function(){
-                            originalSelection = selleckt.$originalSelectEl.find('option:selected');
-                            item.isSelected = true;
-                        });
-
-                        it('selects the new item in the original select', function(done){
-                            expect(originalSelection.val()).toEqual('1');
-
-                            selleckt.addItem(item);
-
-                            var newSelection = selleckt.$originalSelectEl.find('option:selected');
-
-                            setTimeout(function(){
-                                expect(newSelection.length).toEqual(1);
-                                expect(newSelection.val()).toEqual('new value');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('selects the new item in Selleckt', function(done){
-                            var $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-
-                            expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('foo');
-
-                            selleckt.addItem(item);
-
-                            setTimeout(function(){
-                                expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('hides the new item from the Selleckt list', function(done){
-                            expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-
-                            selleckt.addItem(item);
-
-                            setTimeout(function(){
-                                expect(selleckt.$items.find('.item[data-value="new value"]').css('display')).toEqual('none');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('adds the previously selected item back to the Selleckt list', function(done){
-                            expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-
-                            selleckt.addItem(item);
-
-                            setTimeout(function(){
-                                expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('list-item');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('deselects the previously selected item in the Selleckt', function(done){
-                            expect(selleckt.selectedItem.value).toEqual('1');
-                            expect(selleckt.selectedItem.label).toEqual('foo');
-
-                            selleckt.addItem(item);
-
-                            setTimeout(function(){
-                                expect(selleckt.selectedItem.value).toEqual('new value');
-                                expect(selleckt.selectedItem.label).toEqual('new');
-                                done();
-                            }, waitTime);
-                        });
-                    });
-                });
-
-                describe('using addItems to add an array of items', function(){
-                    var items;
-
-                    beforeEach(function(){
-                        items = [
-                            { label: 'new 1', value: 'new value 1' },
-                            { label: 'new 2', value: 'new value 2' },
-                            { label: 'new 3', value: 'new value 3' }
-                        ];
-                    });
-
-                    afterEach(function(){
-                        items = undefined;
-                    });
-
-                    it('adds the items to this.items', function(){
-                        expect(selleckt.items.length).toEqual(3);
-
-                        selleckt.addItems(items);
-
-                        expect(selleckt.items.length).toEqual(6);
-                        expect(selleckt.items[3]).toEqual(items[0]);
-                        expect(selleckt.items[4]).toEqual(items[1]);
-                        expect(selleckt.items[5]).toEqual(items[2]);
-                    });
-
-                    it('appends new options to the original select', function(){
-                        var $originalSelectEl = selleckt.$originalSelectEl;
-
-                        expect($originalSelectEl.children().length).toEqual(3);
-
-                        selleckt.addItems(items);
-
-                        expect($originalSelectEl.children().length).toEqual(6);
-
-                        var newOption1 = $originalSelectEl.find('option').eq(3);
-                        expect(newOption1.text()).toEqual('new 1');
-                        expect(newOption1.val()).toEqual('new value 1');
-
-                        var newOption2 = $originalSelectEl.find('option').eq(4);
-                        expect(newOption2.text()).toEqual('new 2');
-                        expect(newOption2.val()).toEqual('new value 2');
-
-                        var newOption3 = $originalSelectEl.find('option').eq(5);
-                        expect(newOption3.text()).toEqual('new 3');
-                        expect(newOption3.val()).toEqual('new value 3');
-                    });
-
-                    it('appends the new items to the Selleckt element itself', function(done){
-                        var $sellecktEl = selleckt.$sellecktEl;
-                        var itemClass = '.' + selleckt.itemClass;
-
-                        expect($sellecktEl.find(itemClass).length).toEqual(3);
-
-                        selleckt.addItems(items);
-
-                        //because of the dom event
-                        setTimeout(function(){
-                            expect($sellecktEl.find(itemClass).length).toEqual(6);
-                            done();
-                        }, waitTime);
-                    });
-
-                    describe('and a new item has selected:true', function(){
-                        var originalSelection;
-
-                        beforeEach(function(){
-                            originalSelection = selleckt.$originalSelectEl.find('option:selected');
-                            items[0].isSelected = true;
-                        });
-
-                        it('selects the new item in the original select', function(done){
-                            expect(originalSelection.val()).toEqual('1');
-
-                            selleckt.addItems(items);
-
-                            var newSelection = selleckt.$originalSelectEl.find('option:selected');
-
-                            setTimeout(function(){
-                                expect(newSelection.length).toEqual(1);
-                                expect(newSelection.val()).toEqual('new value 1');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('selects the new item in Selleckt', function(done){
-                            var $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-
-                            expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('foo');
-
-                            selleckt.addItems(items);
-
-                            setTimeout(function(){
-                                expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('new 1');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('hides the new item from the Selleckt list', function(done){
-                            expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-
-                            selleckt.addItems(items);
-
-                            setTimeout(function(){
-                                expect(selleckt.$items.find('.item[data-value="new value 1"]').css('display')).toEqual('none');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('adds the previously selected item back to the Selleckt list', function(done){
-                            expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-
-                            selleckt.addItems(items);
-
-                            setTimeout(function(){
-                                expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('list-item');
-                                done();
-                            }, waitTime);
-                        });
-
-                        it('deselects the previously selected item in the Selleckt', function(done){
-                            expect(selleckt.selectedItem.value).toEqual('1');
-                            expect(selleckt.selectedItem.label).toEqual('foo');
-
-                            selleckt.addItems(items);
-
-                            setTimeout(function(){
-                                expect(selleckt.selectedItem.value).toEqual('new value 1');
-                                expect(selleckt.selectedItem.label).toEqual('new 1');
-                                done();
-                            }, waitTime);
-                        });
-                    });
-                });
+            it('renders the selected text element based on this.template', function(){
+                expect(selleckt.$sellecktEl.find('.selectedText').length).toEqual(1);
+                expect(selleckt.$sellecktEl.find('.selectedText').text()).toEqual(selleckt.selectedItem.label);
             });
 
-            describe('Removing items', function(){
-                var removeItemValue;
-                var waitTime = MutationObserver._period ? MutationObserver._period * 2 : 1;
-
-                beforeEach(function(){
-                    selleckt = new SingleSelleckt({
-                        $selectEl : $el
-                    });
-
-                    selleckt.render();
-                });
-
-                afterEach(function(){
-                    selleckt.destroy();
-                    selleckt = undefined;
-                });
-
-                describe('and the removed item is not selected', function(){
-                    beforeEach(function(){
-                        removeItemValue = selleckt.items[2].value;
-                    });
-
-                    it('removes the item from this.items', function(){
-                        expect(selleckt.items.length).toEqual(3);
-                        expect(selleckt.findItem(removeItemValue)).toBeDefined();
-
-                        selleckt.removeItem(removeItemValue);
-
-                        expect(selleckt.items.length).toEqual(2);
-                        expect(selleckt.findItem(removeItemValue)).toBeUndefined();
-                    });
-
-                    it('removes the option with the corresponding value from the original select', function(){
-                        var $originalSelectEl = selleckt.$originalSelectEl;
-
-                        expect($originalSelectEl.children().length).toEqual(3);
-                        expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(1);
-
-                        selleckt.removeItem(removeItemValue);
-
-                        expect($originalSelectEl.children().length).toEqual(2);
-                        expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(0);
-                    });
-
-                    it('removes the corresponding item from the Selleckt element itself', function(done){
-                        var $sellecktEl = selleckt.$sellecktEl;
-                        var itemClass = '.' + selleckt.itemClass;
-
-                        expect($sellecktEl.find(itemClass).length).toEqual(3);
-
-                        selleckt.removeItem(removeItemValue);
-
-                        //because of the dom event
-                        setTimeout(function(){
-                            expect(selleckt.$originalSelectEl.children().length).toEqual(2);
-                            expect($sellecktEl.find(itemClass).length).toEqual(2);
-
-                            done();
-                        }, waitTime);
-                    });
-                });
-
-                describe('and the removed item is selected', function(){
-                    beforeEach(function(){
-                        removeItemValue = selleckt.selectedItem.value;
-                    });
-
-                    it('removes the corresponding item from the Selleckt element itself', function(done){
-                        var $sellecktEl = selleckt.$sellecktEl;
-                        var itemClass = '.' + selleckt.itemClass;
-
-                        expect($sellecktEl.find(itemClass).length).toEqual(3);
-
-                        selleckt.removeItem(removeItemValue);
-
-                        //because of the dom event
-                        setTimeout(function(){
-                            expect(selleckt.$originalSelectEl.children().length).toEqual(2);
-                            expect($sellecktEl.find(itemClass).length).toEqual(2);
-
-                            done();
-                        }, waitTime);
-                    });
-
-                    it('sets this.selectedItem to undefined if it has the value of the item being removed', function(){
-                        expect(selleckt.selectedItem).toBeDefined();
-
-                        selleckt.removeItem(removeItemValue);
-
-                        expect(selleckt.selectedItem).toBeUndefined();
-                    });
-
-                    it('sets the placeholder text back', function(){
-                        expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.selectedItem.label);
-
-                        selleckt.removeItem(removeItemValue);
-
-                        expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.placeholderText);
-                    });
-                });
-
+            it('hides the original Select element', function(){
+                expect(selleckt.$originalSelectEl.css('display')).toEqual('none');
             });
 
-            describe('Events', function(){
-                beforeEach(function(){
-                    selleckt = new SingleSelleckt({
-                        $selectEl : $el
-                    });
-
-                    selleckt.render();
-                });
-
-                describe('showing the options', function(){
-                    var $selectedItem;
-
-                    beforeEach(function(){
-                        $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-                    });
-
-                    afterEach(function(){
-                        $selectedItem = undefined;
-                    });
-
-                    it('shows the options on click on the selected item', function(){
-                        var openStub = sinon.stub(selleckt, '_open'),
-                            isStub = sinon.stub($.fn, 'is').returns(false);
-
-                        selleckt.$sellecktEl.find('.'+selleckt.selectedClass).trigger('click');
-
-                        expect(openStub.calledOnce).toEqual(true);
-
-                        isStub.restore();
-                    });
-                    it('sets absolute positioning on the items container', function(){
-                        var setItemsAbsoluteSpy = sinon.spy(selleckt, '_setItemsAbsolute'),
-                            setItemsFixedSpy = sinon.spy(selleckt, '_setItemsFixed');
-
-                        selleckt._open();
-
-                        expect(setItemsAbsoluteSpy.calledOnce).toEqual(true);
-                        expect(setItemsFixedSpy.called).toEqual(false);
-                        expect(selleckt.$sellecktEl.find('.items').css('position')).toEqual('absolute');
-
-                        setItemsFixedSpy.restore();
-                        setItemsAbsoluteSpy.restore();
-                    });
-                    it('does not call _open when the options are already showing', function(){
-                        var openSpy = sinon.spy(selleckt, '_open'),
-                            isStub = sinon.stub($.fn, 'is').returns(true);
-
-                        $selectedItem.trigger('click');
-                        expect(openSpy.calledOnce).toEqual(false);
-
-                        isStub.restore();
-                    });
-                    it('calls "_close" when the body is clicked', function(){
-                        var openSpy = sinon.spy(selleckt, '_open'),
-                            closeSpy = sinon.spy(selleckt, '_close');
-
-                        selleckt._open();
-
-                        $(document).trigger('click');
-
-                        expect(openSpy.calledOnce).toEqual(true);
-                        expect(closeSpy.calledOnce).toEqual(true);
-                    });
-                    it('triggers a "close" event when _close is called', function(){
-                        var listener = sinon.stub();
-
-                        selleckt.bind('close', listener);
-                        selleckt._close();
-
-                        expect(listener.calledOnce).toEqual(true);
-
-                        selleckt.unbind('close', listener);
-                    });
-                    it('adds a class of "open" to this.$sellecktEl when the selleckt is opened', function(){
-                        selleckt._open();
-
-                        expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
-                    });
-                    it('removes the class of "closed" from this.$sellecktEl when the selleckt is closed', function(){
-                        expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
-
-                        selleckt._open();
-
-                        expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(false);
-                    });
-                    it('removes the  "open" class from this.$sellecktEl when the selleckt is closed', function(){
-                        selleckt._open();
-
-                        expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
-
-                        selleckt._close();
-
-                        expect(selleckt.$sellecktEl.hasClass('open')).toEqual(false);
-                    });
-                    it('adds a class of "closed" to this.$sellecktEl when the selleckt is closed', function(){
-                        selleckt._open();
-
-                        expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(false);
-
-                        selleckt._close();
-
-                        expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
-                    });
-
-                    describe('overflowing options container', function() {
-                        var isOverflowingStub;
-
-                        beforeEach(function(){
-                            isOverflowingStub = sinon.stub(selleckt, '_isOverflowing', function() {
-                                return true;
-                            });
-                        });
-                        afterEach(function(){
-                            isOverflowingStub.restore();
-                        });
-
-                        it('sets fixed positioning on the items container', function(){
-                            var setItemsFixedSpy = sinon.spy(selleckt, '_setItemsFixed'),
-                                setItemsAbsoluteSpy = sinon.spy(selleckt, '_setItemsAbsolute');
-
-                            selleckt._open();
-
-                            expect(setItemsFixedSpy.calledOnce).toEqual(true);
-                            expect(setItemsAbsoluteSpy.called).toEqual(false);
-                            expect(selleckt.$sellecktEl.find('.items').css('position')).toEqual('fixed');
-
-                            setItemsAbsoluteSpy.restore();
-                            setItemsFixedSpy.restore();
-                        });
-                        it('binds to click event on document when options are shown', function(){
-                            var eventsData;
-
-                            selleckt._open();
-
-                            eventsData = $._data(document, 'events');
-
-                            expect(eventsData.click).toBeDefined();
-                            expect(eventsData.click.length).toEqual(1);
-                            expect(eventsData.click[0].namespace).toEqual('selleckt-' + selleckt.id);
-                        });
-                        it('binds to scroll event on $scrollingParent when options are shown', function(){
-                            var eventsData;
-
-                            selleckt._open();
-
-                            eventsData = $._data(selleckt.$scrollingParent[0], 'events');
-
-                            expect(eventsData.scroll).toBeDefined();
-                            expect(eventsData.scroll.length).toEqual(1);
-                            expect(eventsData.scroll[0].namespace).toEqual('selleckt-' + selleckt.id);
-                        });
-                        it('calls "_close" when $scrollingParent is scrolled', function(){
-                            var openSpy = sinon.spy(selleckt, '_open'),
-                                closeSpy = sinon.spy(selleckt, '_close');
-
-                            selleckt._open();
-
-                            $(window).trigger('scroll');
-
-                            expect(openSpy.calledOnce).toEqual(true);
-                            expect(closeSpy.calledOnce).toEqual(true);
-                        });
-                        it('unbinds from scroll event on $scrollingParent when options are hidden', function(){
-                            var eventsData;
-
-                            selleckt._open();
-                            selleckt._close();
-
-                            eventsData = $._data(selleckt.$scrollingParent[0], 'events');
-
-                            expect(eventsData).toBeUndefined();
-                        });
-                        it('displays fixed items container below the trigger', function(){
-                            // move selleckt to top so there's enough room for the dropdown
-                            selleckt.$sellecktEl.css({
-                                position:'absolute', top:0
-                            });
-
-                            selleckt._open();
-
-                            expect(selleckt.$items.offset().top)
-                                .toEqual(selleckt.$sellecktEl.find('.selected').offset().top +
-                                    selleckt.$sellecktEl.find('.selected').outerHeight());
-                            expect(selleckt.$items.hasClass('flipped')).toEqual(false);
-                        });
-                        it('displays fixed items container on top if there\'s not enough space below the trigger', function(){
-                            // create testarea that stretches to the bottom of the screen
-                            var $testArea = $('<div class="testarea">').css({
-                                position:'fixed', top:0, left:0, width:'100%', height:'100%'
-                            }).appendTo('body');
-
-                            // position selleckt in testarea to force the dropdown to go off screen
-                            selleckt.$sellecktEl.css({
-                                position:'absolute', bottom:0, height: '20px', overflow:'hidden'
-                            }).appendTo($testArea);
-
-                            selleckt._open();
-
-                            //IE returns a decimal, so round both up
-                            var itemsOffset = Math.ceil(selleckt.$items.offset().top + selleckt.$items.outerHeight());
-                            var selectedOffset = Math.ceil(selleckt.$sellecktEl.find('.selected').offset().top);
-
-                            //add some tolerance
-                            expect(Math.abs(itemsOffset-selectedOffset)).toBeLessThan(2);
-
-                            expect(selleckt.$items.hasClass('flipped')).toEqual(true);
-
-                            // clean up
-                            $testArea.remove();
-                        });
-                        it('removes "flipped" class from this.$items on _close when the dropdown was displayed on top', function(){
-                            var flipStub = sinon.stub(selleckt, '_flipIfNeeded', function() {
-                                selleckt.$items.addClass('flipped');
-                            });
-
-                            selleckt._open();
-
-                            expect(selleckt.$items.hasClass('flipped')).toEqual(true);
-
-                            selleckt._close();
-
-                            expect(selleckt.$items.hasClass('flipped')).toEqual(false);
-
-                            flipStub.restore();
-                        });
-                    });
-                });
-
-                describe('item selection', function(){
-                    var $selectedItem;
-
-                    beforeEach(function(){
-                        $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-                        $selectedItem.trigger('click');
-                    });
-
-                    it('does not allow multiple items to be selected', function(){
-                        var item1 = 'foo',
-                            item2 = 'bar';
-
-                        selleckt.selectItem(item1);
-                        expect(selleckt.getSelection()).toEqual(item1);
-
-                        selleckt.selectItem(item2);
-                        expect(selleckt.getSelection()).toEqual(item2);
-                    });
-
-                    it('stores the selected item as this.selectedItem', function(){
-                        expect(selleckt.selectedItem).toEqual({
-                            value: '1',
-                            label: 'foo',
-                            data: {}
-                        });
-
-                        selleckt.$sellecktEl.find('li.item').eq(0).trigger('mouseout');
-                        selleckt.$sellecktEl.find('li.item').eq(1).trigger('mouseover').trigger('click');
-
-                        expect(selleckt.selectedItem).toEqual({
-                            value: '2',
-                            label: 'bar',
-                            data: {
-                                meh: 'whee',
-                                bah: 'oink'
-                            }
-                        });
-                    });
-                    it('updates the text of the selected item container with the selectedItem\'s label', function(){
-                        expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('foo');
-
-                        selleckt.$sellecktEl.find('li.item').eq(0).trigger('mouseout');
-                        selleckt.$sellecktEl.find('li.item').eq(1).trigger('mouseover').trigger('click');
-
-                        expect($selectedItem.find('.'+selleckt.selectedTextClass).text()).toEqual('bar');
-                    });
-                    it('triggers an "itemSelected" event with this.selectedItem', function(){
-                        var spy = sinon.spy();
-                        selleckt.bind('itemSelected', spy);
-
-                        selleckt.$sellecktEl.find('li.item').eq(0).trigger('mouseout');
-                        selleckt.$sellecktEl.find('li.item').eq(1).trigger('mouseover').trigger('click');
-
-                        expect(spy.calledOnce).toEqual(true);
-                        expect(spy.args[0][0]).toEqual({
-                            value: '2',
-                            label: 'bar',
-                            data: {
-                                meh: 'whee',
-                                bah: 'oink'
-                            }
-                        });
-                    });
-                    it('hides the selected item from the list', function(){
-                        expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-                    });
-                    it('does not trigger an event when the selected item is clicked, were it to be unhidden', function(){
-                        var spy = sinon.spy(),
-                            $selectedItem = selleckt.$items.find('.item[data-value="1"]');
-
-                        selleckt.bind('itemSelected', spy);
-
-                        $selectedItem.css('display', 'block').trigger('mouseover').trigger('click');
-
-                        expect(spy.called).toEqual(false);
-                    });
-                    it('shows the previously-selected item in the list', function(){
-                        expect(selleckt.$items.find('.item[data-value="1"]').css('display')).toEqual('none');
-
-                        selleckt.$sellecktEl.find('li.item').eq(0).trigger('mouseout');
-                        selleckt.$sellecktEl.find('li.item').eq(1).trigger('mouseover').trigger('click');
-
-                        expect(selleckt.$items.find('.item[data-value="1"]').css('display')).not.toEqual('none');
-                        expect(selleckt.$items.find('.item[data-value="2"]').css('display')).toEqual('none');
-                    });
-                    it('highlights the current item and de-highlights all other items on mouseover', function(){
-                        var highlightClass = selleckt.highlightClass,
-                            liOne = selleckt.$sellecktEl.find('li.item').eq(0), liTwo = selleckt.$sellecktEl.find('li.item').eq(1);
-
-                        expect(liTwo.hasClass(highlightClass)).toEqual(false);
-
-                        liOne.trigger('mouseover');
-                        expect(liOne.hasClass(highlightClass)).toEqual(true);
-
-                        liOne.trigger('mouseout');
-                        expect(liOne.hasClass(highlightClass)).toEqual(true);
-
-                        liTwo.trigger('mouseover');
-                        expect(liOne.hasClass(highlightClass)).toEqual(false);
-                        expect(liTwo.hasClass(highlightClass)).toEqual(true);
-
-                        liTwo.children(':first').trigger('mouseover');
-                        expect(liTwo.children(':first').hasClass(highlightClass)).toEqual(false);
-                        expect(liTwo.hasClass(highlightClass)).toEqual(true);
-                    });
-                    it('removes the highlight class from all items when it closes', function(){
-                        var highlightClass = selleckt.highlightClass;
-
-                        expect(selleckt.$sellecktEl.find('li.item').eq(1).hasClass(highlightClass)).toEqual(false);
-
-                        selleckt.$sellecktEl.find('li.item').eq(1).trigger('mouseover');
-
-                        expect(selleckt.$sellecktEl.find('li.' + highlightClass).length).toEqual(1);
-
-                        selleckt._close();
-
-                        expect(selleckt.$sellecktEl.find('li.' + highlightClass).length).toEqual(0);
-                    });
-                    it('updates the original select element with the new value', function(){
-                        selleckt.selectItem(selleckt.items[1]);
-
-                        expect(selleckt.$originalSelectEl.val()).toEqual(selleckt.items[1].value);
-                    });
-                    it('updates selleckt when change is triggered on original select', function(){
-                        selleckt.$originalSelectEl.val('2').change();
-
-                        expect(selleckt.getSelection().value).toEqual('2');
-                    });
-                    it('updates selleckt when change is triggered on original select with no value', function(){
-                        selleckt.$originalSelectEl.val('').change();
-
-                        expect(selleckt.getSelection().value).toBeUndefined();
-                    });
-                    it('does not update selleckt when change on original select is triggered by selleckt itself', function(){
-                        selleckt.$originalSelectEl.val('2').trigger('change', {origin: 'selleckt'});
-
-                        expect(selleckt.getSelection().value).toEqual('1');
-                    });
-                    it('fires change() event listeners only once when change event is triggered on original select', function(){
-                        var changeStub = sinon.stub();
-                        selleckt.$originalSelectEl.on('change', changeStub);
-                        selleckt.$originalSelectEl.change();
-                        expect(changeStub.callCount).toEqual(1);
-                    });
-
-                    it('triggers a change event on original select when item is selected', function(){
-                        var changeHandler = sinon.spy();
-
-                        selleckt.$originalSelectEl.on('change', changeHandler);
-                        selleckt.selectItem('foo');
-
-                        expect(changeHandler.calledOnce).toEqual(true);
-                        expect(changeHandler.args[0].length).toEqual(2);
-                        expect(changeHandler.args[0][1].origin).toEqual('selleckt');
-
-                        selleckt.$originalSelectEl.off('change', changeHandler);
-                    });
-
-                    describe('with an empty option', function(){
-                        beforeEach(function(){
-                            $el = $(elHtml).append('<option></option>').appendTo('body');
-                            selleckt = new SingleSelleckt({
-                                $selectEl : $el
-                            });
-
-                            selleckt.render();
-                        });
-
-                        it('displays the placeholder when the change event is triggered on ' +
-                                'the original select and its value is the empty string', function(){
-                            selleckt.$originalSelectEl.val('').trigger('change');
-                            var emptyOptionDisplayedText = selleckt.$sellecktEl.find('.selectedText').text();
-                            expect(emptyOptionDisplayedText).toEqual(selleckt.placeholderText);
-                        });
-                    });
-
-                });
-
-                describe('Keyboard input', function(){
-                    var $selectedItem,
-                        KEY_CODES = {
-                            DOWN: 40,
-                            UP: 38,
-                            ENTER: 13,
-                            ESC: 27
-                        };
-
-                    beforeEach(function(){
-                        $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
-
-                        selleckt.$sellecktEl.focus();
-                    });
-
-                    afterEach(function(){
-                        $selectedItem = undefined;
-                    });
-
-                    it('opens the items list when enter is pressed on a closed selleckt', function(){
-                        var isStub = sinon.stub($.fn, 'is').returns(false);
-
-                        expect(selleckt.$sellecktEl.hasClass('open')).toEqual(false);
-
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
-
-                        expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
-
-                        expect(isStub.calledOnce).toEqual(true);
-                        expect(isStub.calledOn(selleckt.$items)).toEqual(true);
-                        expect(isStub.calledWith(':visible')).toEqual(true);
-
-                        isStub.restore();
-                    });
-
-                    it('selects the current item when enter is pressed on an open selleckt', function(){
-                        var spy = sinon.spy(),
-                            isStub;
-
-                        selleckt.bind('itemSelected', spy);
-
-                        selleckt._open();
-
-                        isStub = sinon.stub($.fn, 'is').returns(true);
-
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
-
-                        expect(spy.calledOnce).toEqual(true);
-                        expect(spy.args[0][0]).toEqual({
-                            value: '2',
-                            label: 'bar',
-                            data: {
-                                meh: 'whee',
-                                bah: 'oink'
-                            }
-                        });
-
-                        isStub.restore();
-                    });
-
-                    it('Highlights the next item when DOWN is pressed, the previous when UP is pressed', function(){
-                        var liOne = selleckt.$items.find('.item').eq(0),
-                            liTwo = selleckt.$items.find('.item').eq(1),
-                            liThree = selleckt.$items.find('.item').eq(2);
-
-                        selleckt._open();
-
-                        expect(liOne.is(':visible')).toEqual(false);
-
-                        expect(liTwo.hasClass(selleckt.highlightClass)).toEqual(false);
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
-                        expect(liTwo.hasClass(selleckt.highlightClass)).toEqual(true);
-
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
-                        expect(liTwo.hasClass(selleckt.highlightClass)).toEqual(false);
-                        expect(liThree.hasClass(selleckt.highlightClass)).toEqual(true);
-
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.UP }));
-                        expect(liTwo.hasClass(selleckt.highlightClass)).toEqual(true);
-                        expect(liThree.hasClass(selleckt.highlightClass)).toEqual(false);
-                    });
-
-                    it('closes the selleckt when escape is pressed', function(){
-                        var closeStub = sinon.stub(selleckt, '_close');
-
-                        selleckt._open();
-
-                        selleckt.$sellecktEl.trigger($.Event('keyup', { keyCode : KEY_CODES.ESC }));
-
-                        expect(closeStub.calledOnce).toEqual(true);
-                    });
-
-                    it('resets focus to selleckt after item is selected', function(){
-                        var onFocusStub = sinon.stub();
-
-                        selleckt.$sellecktEl.focus(onFocusStub);
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.DOWN }));
-                        $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
-
-                        expect(onFocusStub.calledOnce).toEqual(true);
-                    });
-                });
+            it('adds a class of "closed" to the element', function(){
+                expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
             });
 
-            describe('search', function(){
-                var selectHtml = '<select>' +
-                        '<option value>Empty</option>' +
-                        '<option value="foo">foo</option>' +
-                        '<option value="bar">bar</option>' +
-                        '<option value="baz">baz</option>' +
-                        '<option value="foofoo">foofoo</option>' +
-                        '<option value="foobaz">foobaz</option>' +
-                        '</select>',
-                    template =
-                    '<div class="{{className}}" tabindex=1>' +
+            it('replaces custom template tags with template data', function(){
+                var customTemplate =
+                    '<div class="{{className}}">' +
+                        '{{#selectLabel}}<label>{{selectLabel}}</label>{{/selectLabel}}' +
+                        '{{#required}}<span class="required">*</span>{{/required}}' +
                         '<div class="selected">' +
                             '<span class="selectedText">{{selectedItemText}}</span><i class="icon-arrow-down"></i>' +
                         '</div>' +
                         '<ul class="items">' +
-                            '{{#showSearch}}' +
-                            '<li class="searchContainer">' +
-                                '<input class="search"></input>' +
-                            '</li>' +
-                            '{{/showSearch}}' +
                             '{{#items}}' +
-                            '<li class="item" data-text="{{label}}" data-value="{{value}}">' +
-                                '<span class="itemText">{{label}}</span>' +
+                            '<li class="item{{#selected}} selected{{/selected}}" data-value="{{value}}">' +
+                                '{{label}}' +
                             '</li>' +
                             '{{/items}}' +
                         '</ul>' +
-                    '</div>',
-                    $searchInput;
+                    '</div>';
 
-                describe('initialization', function(){
-                    it('displays a searchbox if settings.enableSearch is true and ' +
-                            'there are more items than options.searchThreshold', function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true,
-                            searchThreshold: 0
-                        });
+                selleckt.destroy();
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el,
+                    mainTemplate: customTemplate,
+                    mainTemplateData: {
+                        selectLabel: 'Please selleckt',
+                        required: false
+                    }
+                });
+                selleckt.render();
 
-                        selleckt.render();
+                expect(selleckt.$sellecktEl.find('label').length).toEqual(1);
+                expect(selleckt.$sellecktEl.find('label').text()).toEqual('Please selleckt');
+                expect(selleckt.$sellecktEl.find('.required').length).toEqual(0);
+            });
+        });
 
-                        expect(selleckt.$sellecktEl.find('.searchContainer').length).toEqual(1);
-                    });
-                    it('does not display a searchbox if settings.enableSearch is true and ' +
-                            'there are fewer items than options.searchThreshold', function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true,
-                            searchThreshold: 100
-                        });
+        describe('Adding items', function(){
+            var item;
 
-                        selleckt.render();
+            beforeEach(function(){
+                item = {
+                    label: 'new',
+                    value: 'new value'
+                };
 
-                        expect(selleckt.$sellecktEl.find('.searchContainer').length).toEqual(0);
-                    });
-                    it('does not display a searchbox if settings.enableSearch is false', function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: false
-                        });
-
-                        selleckt.render();
-
-                        expect(selleckt.$sellecktEl.find('.searchContainer').length).toEqual(0);
-                    });
-
-                    it('empties the search input when _close() is called', function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true
-                        });
-
-                        selleckt.render();
-
-                        var $searchInput = selleckt.$sellecktEl.find('.' + selleckt.searchInputClass);
-
-                        $searchInput.val('foo');
-
-                        selleckt._close();
-
-                        expect($searchInput.val()).toEqual('');
-                    });
-
-                    it('clears search when _open() is called', function(){
-                        var filterOptionsStub;
-
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true
-                        });
-
-                        selleckt.render();
-
-                        filterOptionsStub = sinon.stub(selleckt, 'filterOptions');
-
-                        selleckt._open();
-
-                        expect(filterOptionsStub.calledOnce).toEqual(true);
-                        expect(filterOptionsStub.calledWith('')).toEqual(true);
-                    });
-
-                    it('unfilters the selections list when _close() is called', function(){
-                        var filterOptionsStub;
-
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true
-                        });
-
-                        selleckt.render();
-
-                        filterOptionsStub = sinon.stub(selleckt, 'filterOptions');
-
-                        selleckt._close();
-
-                        expect(filterOptionsStub.calledOnce).toEqual(true);
-                        expect(filterOptionsStub.calledWith('')).toEqual(true);
-                    });
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
                 });
 
-                describe('filtering', function(){
+                selleckt.render();
+            });
+
+            afterEach(function(){
+                selleckt.destroy();
+                selleckt = undefined;
+            });
+
+            describe('using addItem to add a single item', function(){
+                it('adds an item to this.items', function(){
+                    expect(selleckt.items.length).toEqual(3);
+
+                    selleckt.addItem(item);
+
+                    expect(selleckt.items.length).toEqual(4);
+                    expect(selleckt.items[3]).toEqual(item);
+                });
+
+                it('appends a new option to the original select', function(){
+                    var $originalSelectEl = selleckt.$originalSelectEl;
+
+                    expect($originalSelectEl.children().length).toEqual(3);
+
+                    selleckt.addItem(item);
+
+                    expect($originalSelectEl.children().length).toEqual(4);
+
+                    var newOption = $originalSelectEl.find('option').eq(3);
+
+                    expect(newOption.text()).toEqual('new');
+                    expect(newOption.val()).toEqual('new value');
+                });
+
+                describe('and the new item has selected:true', function(){
+                    var originalSelection;
+
                     beforeEach(function(){
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml),
-                            enableSearch: true
-                        });
-
-                        selleckt.render();
-
-                        $searchInput = selleckt.$sellecktEl.find('.search');
+                        originalSelection = selleckt.$originalSelectEl.find('option:selected');
+                        item.isSelected = true;
                     });
 
-                    afterEach(function(){
-                        $searchInput = undefined;
+                    it('selects the new item in the original select', function(){
+                        expect(originalSelection.val()).toEqual('1');
+
+                        selleckt.addItem(item);
+
+                        var newSelection = selleckt.$originalSelectEl.find('option:selected');
+
+                        expect(newSelection.length).toEqual(1);
+                        expect(newSelection.val()).toEqual('new value');
                     });
 
-                    it('filters out options with empty values', function(){
-                        var output = selleckt._findMatchingOptions(selleckt.items, '');
+                    it('displays the item text in the selleckt element', function(){
+                        selleckt.addItem(item);
 
-                        expect(output.length).toEqual(6);
-                        expect(output[0]).toEqual({ label: 'Empty', value: '', data:{} });
-                    });
-
-                    it('can annotate the items with matchIndexes', function(){
-                        var output = selleckt._findMatchingOptions(selleckt.items, 'ba');
-
-                        expect(output).toEqual([
-                            { label: 'Empty', value: '', data:{} },
-                            { label: 'foo', value: 'foo', data:{} },
-                            { label: 'bar', value: 'bar', data:{}, matchStart: 0, matchEnd: 1 },
-                            { label: 'baz', value: 'baz', data:{}, matchStart: 0, matchEnd: 1 },
-                            { label: 'foofoo', value: 'foofoo', data:{} },
-                            { label: 'foobaz', value: 'foobaz', data:{}, matchStart: 3, matchEnd: 4 }
-                        ]);
-                    });
-
-                    it('filters the available options as the user types in the searchbox', function(done){
-                        selleckt._open();
-
-                        $searchInput.val('baz').trigger('keyup');
-
-                        setTimeout(function(){
-                            expect(selleckt.$items.find('.item').eq(0).css('display')).toEqual('none');
-                            expect(selleckt.$items.find('.item').eq(1).css('display')).toEqual('none');
-                            expect(selleckt.$items.find('.item').eq(2).css('display')).toEqual('none');
-                            expect(selleckt.$items.find('.item').eq(3).css('display')).not.toEqual('none');
-                            expect(selleckt.$items.find('.item').eq(4).css('display')).toEqual('none');
-                            expect(selleckt.$items.find('.item').eq(5).css('display')).not.toEqual('none');
-
-                            done();
-                        }, 1);
-                    });
-
-                    it('wraps matched text in the matching options with a "mark" tag', function(done){
-                        selleckt._open();
-                        $searchInput.val('baz').trigger('keyup');
-
-                        setTimeout(function(){
-                            expect(selleckt.$items.find('.item mark').length).toEqual(2);
-                            expect(selleckt.$items.find('.item mark').parent('.itemText').eq(0).text()).toEqual('baz');
-                            expect(selleckt.$items.find('.item mark').parent('.itemText').eq(1).text()).toEqual('foobaz');
-
-                            done();
-                        }, 1);
-                    });
-
-                    it('escapes the options when filtering and opening', function(){
-                        selleckt.destroy();
-                        selleckt = new SingleSelleckt({
-                            mainTemplate : template,
-                            $selectEl : $(selectHtml.replace(/bar/g, '<b>some HTML</b>')),
-                            enableSearch: true
-                        });
-
-                        selleckt.render();
-                        selleckt._open();
-
-                        var $li = selleckt.$sellecktEl.find('li.item:eq(2)');
-
-                        expect($li.children().length).toEqual(1);
-                        expect($li.children().eq(0).is('span.itemText')).toEqual(true);
-
-                        expect($li.find('.itemText mark').length).toEqual(1);
-                        expect($li.find('.itemText mark').html()).toEqual('');
-                        expect($li.find('.itemText').text()).toEqual('some HTML');
-                    });
-
-                    it('triggers an "optionsFiltered" event after filtering, passing the filter term', function(done){
-                        var listener = sinon.stub();
-
-                        selleckt._open();
-
-                        selleckt.bind('optionsFiltered', listener);
-                        $searchInput.val('aBc').trigger('keyup');
-
-
-                        setTimeout(function(){
-                            expect(listener.calledOnce).toEqual(true);
-                            expect(listener.args[0][0]).toEqual('aBc');
-
-                            done();
-                        }, 1);
+                        expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(item.label);
                     });
                 });
             });
 
-            describe('removal', function(){
+            describe('using addItems to add an array of items', function(){
+                var items;
+
                 beforeEach(function(){
-                    selleckt = new SingleSelleckt({
-                        mainTemplate : mainTemplate,
-                        $selectEl : $el
-                    });
-                    selleckt.render();
+                    items = [
+                        { label: 'new 1', value: 'new value 1' },
+                        { label: 'new 2', value: 'new value 2' },
+                        { label: 'new 3', value: 'new value 3' }
+                    ];
                 });
+
                 afterEach(function(){
-                    selleckt = undefined;
+                    items = undefined;
                 });
 
-                it('removes change event from original select element', function(){
-                    var eventsData = $._data(selleckt.$originalSelectEl[0], 'events');
+                it('adds the items to this.items', function(){
+                    expect(selleckt.items.length).toEqual(3);
 
-                    expect(eventsData.change).toBeDefined();
-                    expect(eventsData.change.length).toEqual(1);
-                    expect(eventsData.change[0].namespace).toEqual('selleckt');
+                    selleckt.addItems(items);
 
-                    selleckt.destroy();
-
-                    expect(eventsData.change).toEqual(undefined);
+                    expect(selleckt.items.length).toEqual(6);
+                    expect(selleckt.items[3]).toEqual(items[0]);
+                    expect(selleckt.items[4]).toEqual(items[1]);
+                    expect(selleckt.items[5]).toEqual(items[2]);
                 });
 
-                it('removes selleckt data from original select element', function(){
-                    $el.data('selleckt', selleckt);
+                it('appends new options to the original select', function(){
+                    var $originalSelectEl = selleckt.$originalSelectEl;
 
-                    selleckt.destroy();
+                    expect($originalSelectEl.children().length).toEqual(3);
 
-                    expect($el.data('selleckt')).toEqual(undefined);
+                    selleckt.addItems(items);
+
+                    expect($originalSelectEl.children().length).toEqual(6);
+
+                    var newOption1 = $originalSelectEl.find('option').eq(3);
+                    expect(newOption1.text()).toEqual('new 1');
+                    expect(newOption1.val()).toEqual('new value 1');
+
+                    var newOption2 = $originalSelectEl.find('option').eq(4);
+                    expect(newOption2.text()).toEqual('new 2');
+                    expect(newOption2.val()).toEqual('new value 2');
+
+                    var newOption3 = $originalSelectEl.find('option').eq(5);
+                    expect(newOption3.text()).toEqual('new 3');
+                    expect(newOption3.val()).toEqual('new value 3');
                 });
 
-                it('shows original select element', function(){
-                    expect($el.css('display')).toEqual('none');
+                describe('and a new item has selected:true', function(){
+                    var originalSelection;
 
-                    selleckt.destroy();
+                    beforeEach(function(){
+                        originalSelection = selleckt.$originalSelectEl.find('option:selected');
+                        items[0].isSelected = true;
+                    });
 
-                    expect($el.css('display')).toEqual('inline-block');
+                    it('selects the new item in the original select', function(){
+                        expect(originalSelection.val()).toEqual('1');
+
+                        selleckt.addItems(items);
+
+                        var newSelection = selleckt.$originalSelectEl.find('option:selected');
+
+                        expect(newSelection.length).toEqual(1);
+                        expect(newSelection.val()).toEqual('new value 1');
+                    });
+
+                    it('displays the item text in the selleckt element', function(){
+                        selleckt.addItems(items);
+
+                        expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(items[0].label);
+                    });
                 });
-
-                it('stops observing mutation events', function(){
-                    var stopObservingMutationsSpy = sinon.spy(selleckt, '_stopObservingMutations');
-
-                    selleckt.destroy();
-
-                    expect(stopObservingMutationsSpy.calledOnce).toEqual(true);
-                });
-
             });
+        });
+
+        describe('Removing items', function(){
+            var removeItemValue;
+
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+            });
+
+            afterEach(function(){
+                selleckt.destroy();
+                selleckt = undefined;
+            });
+
+            describe('and the removed item is not selected', function(){
+                beforeEach(function(){
+                    removeItemValue = selleckt.items[2].value;
+                });
+
+                it('removes the item from this.items', function(){
+                    expect(selleckt.items.length).toEqual(3);
+                    expect(selleckt.findItem(removeItemValue)).toBeDefined();
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.items.length).toEqual(2);
+                    expect(selleckt.findItem(removeItemValue)).toBeUndefined();
+                });
+
+                it('removes the option with the corresponding value from the original select', function(){
+                    var $originalSelectEl = selleckt.$originalSelectEl;
+
+                    expect($originalSelectEl.children().length).toEqual(3);
+                    expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(1);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect($originalSelectEl.children().length).toEqual(2);
+                    expect($originalSelectEl.find('option[value="' + removeItemValue + '"]').length).toEqual(0);
+                });
+            });
+
+            describe('and the removed item is selected', function(){
+                beforeEach(function(){
+                    removeItemValue = selleckt.selectedItem.value;
+                });
+
+                it('sets this.selectedItem to undefined if it has the value of the item being removed', function(){
+                    expect(selleckt.selectedItem).toBeDefined();
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.selectedItem).toBeUndefined();
+                });
+
+                it('sets the placeholder text back', function(){
+                    expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.selectedItem.label);
+
+                    selleckt.removeItem(removeItemValue);
+
+                    expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual(selleckt.placeholderText);
+                });
+            });
+
+        });
+
+        describe('showing the popup', function(){
+            var $selectedItem,
+                makePopupStub;
+
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+
+                makePopupStub = sandbox.stub(selleckt, '_makePopup');
+
+                selleckt.render();
+
+                $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
+            });
+
+            afterEach(function(){
+                selleckt._close();
+
+                $selectedItem = undefined;
+            });
+
+            it('shows the popup on click on the selected item', function(){
+                $selectedItem.trigger('click');
+
+                expect(makePopupStub.calledOnce).toEqual(true);
+            });
+
+            it('does not call _makePopup when the popup is already showing', function(){
+                $selectedItem.trigger('click');
+
+                expect(makePopupStub.calledOnce).toEqual(true);
+
+                makePopupStub.reset();
+
+                $selectedItem.trigger('click');
+
+                expect(makePopupStub.called).toEqual(false);
+            });
+
+            it('calls "_close" when the body is clicked', function(){
+                var closeSpy = sandbox.spy(selleckt, '_close');
+
+                selleckt._open();
+
+                $(document).trigger('click');
+
+                expect(closeSpy.calledOnce).toEqual(true);
+            });
+
+            it('triggers a "close" event when _close is called', function(){
+                var listener = sinon.stub();
+
+                selleckt.bind('close', listener);
+                selleckt._close();
+
+                expect(listener.calledOnce).toEqual(true);
+
+                selleckt.unbind('close', listener);
+            });
+
+            it('adds a class of "open" to this.$sellecktEl when the selleckt is opened', function(){
+                selleckt._open();
+
+                expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
+            });
+
+            it('removes the class of "closed" from this.$sellecktEl when the selleckt is closed', function(){
+                expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
+
+                selleckt._open();
+
+                expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(false);
+            });
+
+            it('removes the  "open" class from this.$sellecktEl when the selleckt is closed', function(){
+                selleckt._open();
+
+                expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
+
+                selleckt._close();
+
+                expect(selleckt.$sellecktEl.hasClass('open')).toEqual(false);
+            });
+
+            it('adds a class of "closed" to this.$sellecktEl when the selleckt is closed', function(){
+                selleckt._open();
+
+                expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(false);
+
+                selleckt._close();
+
+                expect(selleckt.$sellecktEl.hasClass('closed')).toEqual(true);
+            });
+
+            it('binds to click event on document when options are shown', function(){
+                var eventsData;
+
+                selleckt._open();
+
+                eventsData = $._data(document, 'events');
+
+                expect(eventsData.click).toBeDefined();
+                expect(eventsData.click.length).toEqual(1);
+                expect(eventsData.click[0].namespace).toEqual('selleckt-' + selleckt.id);
+            });
+        });
+
+        describe('popup options', function(){
+            var popup;
+
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el,
+                    itemsClass: 'items',
+                    itemslistClass: 'itemslist',
+                    itemClass: 'item',
+                    itemTextClass: 'itemText',
+                    searchInputClass: 'search',
+                    showSearch: true
+                });
+
+                selleckt.render();
+                selleckt._open();
+
+                popup = selleckt.popup;
+            });
+
+            afterEach(function(){
+                selleckt._close();
+            });
+
+            it('passes this.popupTemplate to the popup', function(){
+                expect(popup.template).toEqual(selleckt.popupTemplate);
+            });
+
+            it('passes this.popupTemplateData to the popup', function(){
+                expect(popup.templateData).toEqual(selleckt.popupTemplateData);
+            });
+
+            it('passes this.itemTemplate to the popup', function(){
+                expect(popup.itemTemplate).toEqual(selleckt.itemTemplate);
+            });
+
+            it('passes this.itemsClass to the popup', function(){
+                expect(popup.itemsClass).toEqual(selleckt.itemsClass);
+            });
+
+            it('passes this.itemslistClass to the popup', function(){
+                expect(popup.itemslistClass).toEqual(selleckt.itemslistClass);
+            });
+
+            it('passes this.itemClass to the popup', function(){
+                expect(popup.itemClass).toEqual(selleckt.itemClass);
+            });
+
+            it('passes this.itemTextClass to the popup', function(){
+                expect(popup.itemTextClass).toEqual(selleckt.itemTextClass);
+            });
+
+            it('passes this.searchInputClass to the popup', function(){
+                expect(popup.searchInputClass).toEqual(selleckt.searchInputClass);
+            });
+
+            it('passes this.showSearch to the popup', function(){
+                expect(popup.showSearch).toEqual(selleckt.showSearch);
+            });
+        });
+
+        describe('item selection', function(){
+            var popup;
+
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+                selleckt._open();
+
+                popup = selleckt.popup;
+            });
+
+            afterEach(function(){
+                selleckt._close();
+            });
+
+            it('does not allow multiple items to be selected', function(){
+                popup.trigger('valueSelected', '2');
+
+                expect(selleckt.selectedItem).toEqual({
+                    value: '2',
+                    label: 'bar',
+                    data: {
+                        bah: 'oink',
+                        meh: 'whee'
+                    }
+                });
+
+                popup.trigger('valueSelected', '1');
+
+                expect(selleckt.selectedItem).toEqual({
+                    value: '1',
+                    label: 'foo',
+                    data: {}
+                });
+            });
+
+            it('updates the text of the selected item container with the selectedItem\'s label', function(){
+                popup.trigger('valueSelected', '2');
+
+                expect(selleckt.$sellecktEl.find('.'+selleckt.selectedTextClass).text()).toEqual('bar');
+            });
+
+            it('triggers an "itemSelected" event with this.selectedItem', function(){
+                var spy = sandbox.spy();
+
+                selleckt.bind('itemSelected', spy);
+
+                popup.trigger('valueSelected', '2');
+
+                expect(spy.calledOnce).toEqual(true);
+                expect(spy.args[0][0]).toEqual(selleckt.selectedItem);
+            });
+
+            it('does not trigger an event when the selected item is clicked, were it to be unhidden', function(){
+                var spy = sinon.spy();
+
+                popup.trigger('valueSelected', '1');
+
+                selleckt.bind('itemSelected', spy);
+
+                popup.trigger('valueSelected', '1');
+                expect(spy.called).toEqual(false);
+            });
+
+            it('updates the original select element with the new value', function(){
+                popup.trigger('valueSelected', '2');
+
+                expect(selleckt.$originalSelectEl.val()).toEqual('2');
+            });
+
+            it('updates selleckt when change is triggered on original select', function(){
+                selleckt.$originalSelectEl.val('2').change();
+
+                expect(selleckt.getSelection().value).toEqual('2');
+            });
+
+            it('updates selleckt when change is triggered on original select with no value', function(){
+                selleckt.$originalSelectEl.val('').change();
+
+                expect(selleckt.getSelection().value).toBeUndefined();
+            });
+
+            it('does not update selleckt when change on original select is triggered by selleckt itself', function(){
+                selleckt.$originalSelectEl.val('2').trigger('change', {origin: 'selleckt'});
+
+                expect(selleckt.getSelection().value).toEqual('1');
+            });
+
+            it('triggers a change event on original select when item is selected', function(){
+                var changeHandler = sinon.spy();
+
+                selleckt.$originalSelectEl.on('change', changeHandler);
+
+                popup.trigger('valueSelected', '2');
+
+                expect(changeHandler.calledOnce).toEqual(true);
+                expect(changeHandler.args[0].length).toEqual(2);
+                expect(changeHandler.args[0][1].origin).toEqual('selleckt');
+
+                selleckt.$originalSelectEl.off('change', changeHandler);
+            });
+
+            describe('with an empty option', function(){
+                it('displays the placeholder when the change event is triggered on ' +
+                        'the original select and its value is the empty string', function(){
+
+                    selleckt.$originalSelectEl.append('<option></option>');
+
+                    selleckt.$originalSelectEl.val('').trigger('change');
+
+                    var emptyOptionDisplayedText = selleckt.$sellecktEl.find('.selectedText').text();
+
+                    expect(emptyOptionDisplayedText).toEqual(selleckt.placeholderText);
+                });
+            });
+
+            describe('hiding the selected item', function(){
+                it('hides the selected item from the list if this.hideSelectedItem == true', function(){
+                    expect(selleckt.getItemsForPopup().length).toEqual(3);
+
+                    selleckt.hideSelectedItem = true;
+
+                    expect(selleckt.getItemsForPopup().length).toEqual(2);
+                });
+                it('does not hide the selected item from the list if this.hideSelectedItem == false', function(){
+                    expect(selleckt.getItemsForPopup().length).toEqual(3);
+
+                    selleckt.hideSelectedItem = false;
+
+                    expect(selleckt.getItemsForPopup().length).toEqual(3);
+                });
+            });
+        });
+
+        describe('Keyboard input', function(){
+            var $selectedItem,
+                KEY_CODES = {
+                    DOWN: 40,
+                    UP: 38,
+                    ENTER: 13,
+                    ESC: 27
+                };
+
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+
+                $selectedItem = selleckt.$sellecktEl.find('.'+selleckt.selectedClass);
+
+                selleckt.$sellecktEl.focus();
+            });
+
+            afterEach(function(){
+                selleckt._close();
+                $selectedItem = undefined;
+            });
+
+            it('opens the items list when enter is pressed on a closed selleckt', function(){
+                expect(selleckt.$sellecktEl.hasClass('open')).toEqual(false);
+
+                var makePopupStub = sandbox.stub(selleckt,  '_makePopup');
+
+                $selectedItem.trigger($.Event('keydown', { which : KEY_CODES.ENTER }));
+
+                expect(selleckt.$sellecktEl.hasClass('open')).toEqual(true);
+
+                expect(makePopupStub.calledOnce).toEqual(true);
+            });
+
+            it('resets focus to selleckt after item is selected', function(){
+                selleckt._open();
+                selleckt.popup.trigger('itemSelected', '2');
+
+                var focusStub = sandbox.stub($.fn, 'focus');
+                selleckt.popup.close();
+
+                expect(focusStub.callCount).toEqual(1);
+                expect(focusStub.thisValues[0].is(selleckt.$sellecktEl)).toEqual(true);
+            });
+        });
+
+        describe('search', function(){
+            var selectHtml = '<select>' +
+                    '<option value>Empty</option>' +
+                    '<option value="foo">foo</option>' +
+                    '<option value="bar">bar</option>' +
+                    '<option value="baz">baz</option>' +
+                    '<option value="foofoo">foofoo</option>' +
+                    '<option value="foobaz">foobaz</option>' +
+                    '</select>';
+
+            var $searchInput;
+
+            afterEach(function(){
+                selleckt._close();
+                $searchInput = undefined;
+            });
+
+            describe('rendering', function(){
+                it('shows the search input if settings.enableSearch is true and ' +
+                    'there are more items than options.searchThreshold', function(){
+                    selleckt = new SingleSelleckt({
+                        $selectEl : $(selectHtml),
+                        enableSearch: true,
+                        searchThreshold: 0
+                    });
+
+                    selleckt.render();
+                    selleckt._open();
+
+                    expect(selleckt.popup.$popup.find('.' + selleckt.searchInputClass).length).toEqual(1);
+                });
+
+                it('does not display a searchbox if settings.enableSearch is true and ' +
+                        'there are fewer items than options.searchThreshold', function(){
+                    selleckt = new SingleSelleckt({
+                        $selectEl : $(selectHtml),
+                        enableSearch: true,
+                        searchThreshold: 100
+                    });
+
+                    selleckt.render();
+                    selleckt._open();
+
+                    expect(selleckt.popup.$popup.find('.' + selleckt.searchInputClass).length).toEqual(0);
+                });
+
+                it('does not display a searchbox if settings.enableSearch is false', function(){
+                    selleckt = new SingleSelleckt({
+                        $selectEl : $(selectHtml),
+                        enableSearch: false
+                    });
+
+                    selleckt.render();
+                    selleckt._open();
+
+                    expect(selleckt.popup.$popup.find('.' + selleckt.searchInputClass).length).toEqual(0);
+                });
+            });
+        });
+
+        describe('filtering', function(){
+            it('filters out options with empty values', function(){
+                var selleckt = new SingleSelleckt({
+                    $selectEl: $('<select>')
+                });
+
+                selleckt.items = [
+                    {label: 'Empty'},
+                    {label: 'Foo', value: '1'},
+                ];
+
+                var filteredItems = selleckt._filterItems(selleckt.items, 'foo');
+
+                expect(filteredItems.length).toEqual(1);
+                expect(filteredItems[0]).toEqual({ label: 'Foo', value: '1', matchStart: 0, matchEnd: 2 });
+            });
+
+            it('can annotate the items with matchIndexes', function(){
+                var selleckt = new SingleSelleckt({
+                    $selectEl: $('<select>')
+                });
+
+                selleckt.items = [
+                    {label: 'foo', value: 'foo'},
+                    {label: 'bar', value: 'bar'},
+                    {label: 'baz', value: 'baz'},
+                    {label: 'foofoo', value: 'foofoo'},
+                    {label: 'foobaz', value: 'foobaz'}
+                ];
+
+                var filteredItems = selleckt._filterItems(selleckt.items, 'ba');
+
+                expect(filteredItems).toEqual([
+                    { label: 'bar', value: 'bar', matchStart: 0, matchEnd: 1 },
+                    { label: 'baz', value: 'baz', matchStart: 0, matchEnd: 1 },
+                    { label: 'foobaz', value: 'foobaz', matchStart: 3, matchEnd: 4 }
+                ]);
+            });
+
+            it('triggers an "optionsFiltered" event after filtering, passing the filter term', function(){
+                var spy = sandbox.spy();
+
+                selleckt = new SingleSelleckt({
+                    $selectEl : $('<select><option value="foo">foo</option><option value="bar">bar</option></select>'),
+                    enableSearch: true,
+                    searchThreshold: 0
+                });
+
+                selleckt.render();
+                selleckt._open();
+
+                selleckt.bind('optionsFiltered', spy);
+
+                selleckt._refreshPopupWithSearchHits('ba');
+
+                expect(spy.callCount).toEqual(1);
+                expect(spy.args[0][0]).toEqual('ba');
+
+                selleckt._close();
+                selleckt.destroy();
+            });
+        });
+
+        describe('removal', function(){
+            beforeEach(function(){
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+                selleckt.render();
+            });
+            afterEach(function(){
+                selleckt = undefined;
+            });
+
+            it('removes change event from original select element', function(){
+                var eventsData = $._data(selleckt.$originalSelectEl[0], 'events');
+
+                expect(eventsData.change).toBeDefined();
+                expect(eventsData.change.length).toEqual(1);
+                expect(eventsData.change[0].namespace).toEqual('selleckt');
+
+                selleckt.destroy();
+
+                expect(eventsData.change).toEqual(undefined);
+            });
+
+            it('removes selleckt data from original select element', function(){
+                $el.data('selleckt', selleckt);
+
+                selleckt.destroy();
+
+                expect($el.data('selleckt')).toEqual(undefined);
+            });
+
+            it('shows original select element', function(){
+                expect($el.css('display')).toEqual('none');
+
+                selleckt.destroy();
+
+                expect($el.css('display')).toEqual('inline-block');
+            });
+
+            it('stops observing mutation events', function(){
+                var stopObservingMutationsSpy = sinon.spy(selleckt, '_stopObservingMutations');
+
+                selleckt.destroy();
+
+                expect(stopObservingMutationsSpy.calledOnce).toEqual(true);
+            });
+
         });
     });
 }

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -708,8 +708,15 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
         describe('popup options', function(){
             var popup;
+            var outerWidthStub;
+            var cssStub;
+            var dummyWidth;
 
             beforeEach(function(){
+                dummyWidth = 100;
+                outerWidthStub = sandbox.stub($.fn, 'outerWidth').returns(dummyWidth);
+                cssStub = sandbox.stub($.fn, 'css');
+
                 selleckt = new SingleSelleckt({
                     $selectEl : $el,
                     itemsClass: 'items',
@@ -764,6 +771,14 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
             it('passes this.showSearch to the popup', function(){
                 expect(popup.showSearch).toEqual(selleckt.showSearch);
+            });
+
+            it('passes the outer width of the selleckt element to the popup as options.css', function(){
+                expect(outerWidthStub.calledOnce).toEqual(true);
+                expect(outerWidthStub.thisValues[0].is(selleckt.$sellecktEl)).toEqual(true);
+
+                expect(cssStub.thisValues[1].is(popup.$popup));
+                expect(cssStub.args[0][0]).toEqual({minWidth: dummyWidth + 'px'});
             });
         });
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -706,6 +706,37 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             });
         });
 
+        describe('when the popup closes', function(){
+            var closeSpy;
+
+            beforeEach(function(){
+
+                closeSpy = sandbox.spy(SingleSelleckt.prototype, '_close');
+
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+
+                selleckt.render();
+            });
+
+            it('calls selleckt._close if selleckt is open', function(){
+                selleckt._open();
+
+                selleckt.popup.trigger('close');
+
+                expect(closeSpy.calledOnce).toEqual(true);
+            });
+
+            it('sets tabindex to -1 on the selleckt element if selleckt is open', function(){
+                selleckt._open();
+
+                selleckt.popup.trigger('close');
+
+                expect(selleckt.$sellecktEl.attr('tabindex')).toEqual('-1');
+            });
+        });
+
         describe('popup options', function(){
             var popup;
             var outerWidthStub;

--- a/test/unit.js
+++ b/test/unit.js
@@ -2,3 +2,4 @@
 
 require('./specs/singleSelleckt.specs.js');
 require('./specs/multiSelleckt.specs.js');
+require('./specs/sellecktPopup.specs.js');


### PR DESCRIPTION
I felt that Selleckt was getting pretty overcomplicated when it came to
positioning the popup containing the options.

This PR refactors the popup out into a separate class. The popup itself
now attaches to the DOM inside the body element, and adds a handler so
that it stays aligned with the opening element when the window resizes.

One other advantage of the popup being separate is that now we dont need
to track the state of the items inside it - we simply blow the whole popup
away when we close (or search within!) it. This makes it a lot easier to
reason with in the code.