### PR TITLE
Preselected options should be rendered

### DIFF
--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.selleckt=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.selleckt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 var KEY_CODES = {
@@ -892,7 +892,7 @@ _.extend(SingleSelleckt.prototype, {
                     data: $option.data()
                 };
 
-            if($option.attr('selected')){
+            if(option.selected){
                 memo.selectedItems.push(item);
             }
 

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -229,7 +229,7 @@ _.extend(SingleSelleckt.prototype, {
                     data: $option.data()
                 };
 
-            if($option.attr('selected')){
+            if(option.selected){
                 memo.selectedItems.push(item);
             }
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -233,17 +233,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                     describe('when there is no selected item already', function(){
                         var $newEl;
 
-                        beforeEach(function(){
-                            var selectHtml = '<select>' +
-                            '<option value="1">foo</option>' +
-                            '<option value="2">bar</option>' +
-                            '<option value="3">baz</option>' +
-                            '</select>';
-
-                            selleckt.destroy();
-
-                            $newEl = $(selectHtml).appendTo($testArea);
-
+                        function buildSelleckt() {
                             selleckt = new SingleSelleckt({
                                 mainTemplate: template,
                                 $selectEl : $newEl,
@@ -255,6 +245,19 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                                 selectedClassName: 'isSelected',
                                 highlightClass: 'isHighlighted'
                             });
+                        }
+
+                        beforeEach(function(){
+                            var selectHtml = '<select>' +
+                            '<option value="1">foo</option>' +
+                            '<option value="2">bar</option>' +
+                            '<option value="3">baz</option>' +
+                            '</select>';
+
+                            selleckt.destroy();
+
+                            $newEl = $(selectHtml).appendTo($testArea);
+                            buildSelleckt();
                         });
 
                         afterEach(function(){
@@ -264,6 +267,22 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
                         it('does not select an item', function(){
                             expect(selleckt.selectedItem).toBeUndefined();
+                        });
+
+                        describe('if an item is selected via the DOM API', function() {
+                            beforeEach(function() {
+                                selleckt.destroy();
+                                $newEl.val('1');
+                                buildSelleckt();
+                            });
+
+                            it('preselects the item', function() {
+                                expect(selleckt.selectedItem).toEqual({
+                                    value: '1',
+                                    label: 'foo',
+                                    data: {}
+                                });
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
Options can be selected by setting the `selected` property onto
their respective DOM elements.
If an option has a 'selected' attribute, the browser will set
the corresponding DOM property: the fix therefore works in both cases.

I've been unable to run the tests locally so I'm hoping this will be green @grahamscott 