### PR TITLE
Item filtering fix

### DIFF
--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -875,12 +875,21 @@ _.extend(SingleSelleckt.prototype, {
 
     _refreshPopupWithSearchHits: function(term){
         var matchingItems = this._filterItems(this.items, term);
+        var hideSelectedItem = this.hideSelectedItem;
+        var selectedItem = this.selectedItem;
+        var itemsToShow;
 
-        this.popup.refreshItems(matchingItems);
-
-        if(matchingItems.length < this.items.length){
-            this.trigger('optionsFiltered', term);
+        if(selectedItem && hideSelectedItem){
+            itemsToShow = _.filter(matchingItems, function(item) {
+                return item.value !== selectedItem.value;
+            });
+        } else {
+            itemsToShow = matchingItems;
         }
+
+        this.popup.refreshItems(itemsToShow);
+
+        this.trigger('optionsFiltered', term);
     },
 
     _parseItemsFromOptions: function($selectEl){

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -212,12 +212,21 @@ _.extend(SingleSelleckt.prototype, {
 
     _refreshPopupWithSearchHits: function(term){
         var matchingItems = this._filterItems(this.items, term);
+        var hideSelectedItem = this.hideSelectedItem;
+        var selectedItem = this.selectedItem;
+        var itemsToShow;
 
-        this.popup.refreshItems(matchingItems);
-
-        if(matchingItems.length < this.items.length){
-            this.trigger('optionsFiltered', term);
+        if(selectedItem && hideSelectedItem){
+            itemsToShow = _.filter(matchingItems, function(item) {
+                return item.value !== selectedItem.value;
+            });
+        } else {
+            itemsToShow = matchingItems;
         }
+
+        this.popup.refreshItems(itemsToShow);
+
+        this.trigger('optionsFiltered', term);
     },
 
     _parseItemsFromOptions: function($selectEl){

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -1135,6 +1135,30 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 ]);
             });
 
+            it('does not refresh the popup with this.selectedItem, if this.hideSelectedItem === true', function() {
+                selleckt = new SingleSelleckt({
+                    $selectEl : $('<select>' +
+                        '<option value="foo">foo</option>' +
+                        '<option value="bar">bar</option>' +
+                        '<option value="baz">baz</option>' +
+                        '</select>'),
+                    enableSearch: true,
+                    searchThreshold: 0,
+                    hideSelectedItem: true
+                });
+
+                selleckt.selectItemByValue('bar');
+
+                selleckt.render();
+                selleckt._open();
+
+                selleckt._refreshPopupWithSearchHits('ba');
+
+                expect(selleckt.popup.$popup.find('.item').length).toEqual(1);
+                expect(selleckt.popup.$popup.find('.item[data-value=bar]').length).toEqual(0);
+                expect(selleckt.popup.$popup.find('.item[data-value=baz]').length).toEqual(1);
+            });
+
             it('triggers an "optionsFiltered" event after filtering, passing the filter term', function(){
                 var spy = sandbox.spy();
 


### PR DESCRIPTION
Tweak for item filtering:

1. If the "hideSelectedItem" property is true, the popup should not
refresh with the selected item visible.

2. Additionally, the 'optionsFiltered' event should always be triggered
when the popup is refreshed.