### PR TITLE
Selleckt karma fix

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,8 +33,7 @@ module.exports = function(config) {
         },
 
         browserify: {
-            debug: true,
-            transform: ['brfs']
+            debug: true
         },
 
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "karma-mocha": "^0.1.10",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
-    "mocha": "^2.1"
+    "mocha": "^2.1",
+    "mustache": "^2.0.0",
+    "underscore": "^1.8.3"
   },
   "optionalDependencies": {},
   "browser": {


### PR DESCRIPTION
Missing/Superfluous dependencies were causing `npm test` to fail.