### PR TITLE
Select item by value fix

### DIFF
--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -1083,6 +1083,10 @@ _.extend(SingleSelleckt.prototype, {
     selectItemByValue: function(value, options) {
         var item = this.findItem(value);
 
+        if(!item){
+            return;
+        }
+
         this.selectItem(item, options);
     },
 

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -420,6 +420,10 @@ _.extend(SingleSelleckt.prototype, {
     selectItemByValue: function(value, options) {
         var item = this.findItem(value);
 
+        if(!item){
+            return;
+        }
+
         this.selectItem(item, options);
     },
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -845,6 +845,16 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 expect(selectItemStub.args[0][1]).toEqual(options);
             });
 
+            it('does nothing if the selectItemByValue is called with a value that does not exist', function () {
+                var selectItemStub = sandbox.stub(SingleSelleckt.prototype, 'selectItem');
+
+                sandbox.stub(SingleSelleckt.prototype, 'findItem').returns(undefined);
+
+                selleckt.selectItemByValue(100);
+
+                expect(selectItemStub.called).toEqual(false);
+            });
+
             it('does not allow multiple items to be selected', function(){
                 popup.trigger('valueSelected', '2');
 


### PR DESCRIPTION
The convenience function `selectItemByValue` should not call `selectItem` if an item with the supplied value is not found in the collection.