### PR TITLE
NRP-2976 do not emit event on programmatic changes

### DIFF
--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.selleckt=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.selleckt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 var KEY_CODES = {
@@ -162,9 +162,8 @@ MultiSelleckt.prototype.selectItem = function(item, options){
 
     if (!options.silent) {
         this.updateOriginalSelect();
+        this.trigger('itemSelected', item);
     }
-
-    this.trigger('itemSelected', item);
 };
 
 MultiSelleckt.prototype.updateOriginalSelect = function(){
@@ -1075,9 +1074,8 @@ _.extend(SingleSelleckt.prototype, {
 
         if (!options.silent) {
             this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
+            this.trigger('itemSelected', item);
         }
-
-        this.trigger('itemSelected', item);
     },
 
     selectItemByValue: function(value, options) {

--- a/lib/MultiSelleckt.js
+++ b/lib/MultiSelleckt.js
@@ -96,9 +96,8 @@ MultiSelleckt.prototype.selectItem = function(item, options){
 
     if (!options.silent) {
         this.updateOriginalSelect();
+        this.trigger('itemSelected', item);
     }
-
-    this.trigger('itemSelected', item);
 };
 
 MultiSelleckt.prototype.updateOriginalSelect = function(){

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -412,9 +412,8 @@ _.extend(SingleSelleckt.prototype, {
 
         if (!options.silent) {
             this.$originalSelectEl.val(item.value).trigger('change', {origin: 'selleckt'});
+            this.trigger('itemSelected', item);
         }
-
-        this.trigger('itemSelected', item);
     },
 
     selectItemByValue: function(value, options) {

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -332,6 +332,16 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
                 expect(multiSelleckt.$originalSelectEl.val()).toEqual(['2','3']);
             });
 
+            it('does not trigger an "itemSelected" event when option.silent is passed', function(){
+                var spy = sandbox.spy();
+
+                multiSelleckt.bind('trigger', spy);
+
+                multiSelleckt.selectItem(1, {silent: true});
+
+                expect(spy.calledWith('itemSelected')).toEqual(false);
+            });
+
             describe('item deselection', function(){
                 it('removes an item when the "unselect" link is clicked', function(){
                     multiSelleckt.render();

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -893,6 +893,16 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 expect(spy.args[0][0]).toEqual(selleckt.selectedItem);
             });
 
+            it('does not trigger an "itemSelected" event when option.silent is passed', function(){
+                var spy = sandbox.spy();
+
+                selleckt.bind('trigger', spy);
+
+                selleckt.selectItem(1, {silent: true});
+
+                expect(spy.calledWith('itemSelected')).toEqual(false);
+            });
+
             it('does not trigger an event when the selected item is clicked, were it to be unhidden', function(){
                 var spy = sinon.spy();
 


### PR DESCRIPTION
Hey @grahamscott,
so that we are able to distinguish between programmatic changes and user input changes `selleckt.selectItem(123, {silent: true})` won't trigger the event `itemSelected` anymore as it did before.

Thanks