### PR TITLE
Fix hide selected items for multipleselleckt search

### DIFF
--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -142,6 +142,14 @@ MultiSelleckt.prototype._mutationHandler = function (mutations){
     });
 };
 
+MultiSelleckt.prototype._filterSelection = function (items, selection) {
+    var selectionValues = _.pluck(selection, 'value');
+
+    return _.filter(items, function(item) {
+        return selectionValues.indexOf(item.value) === -1;
+    });
+};
+
 MultiSelleckt.prototype.selectItem = function(item, options){
     options = options || {};
 
@@ -420,9 +428,7 @@ _.extend(SellecktPopup.prototype, {
         var $rendered = _.map(items, function(item){
             var itemEl = Mustache.render(this.itemTemplate, _.extend({
                 itemTextClass: this.itemTextClass,
-                itemClass: this.itemClass,
-                label: item.label,
-                value: item.value
+                itemClass: this.itemClass
             }, item));
 
             if(item.matchEnd > 0){
@@ -872,16 +878,20 @@ _.extend(SingleSelleckt.prototype, {
         }, []);
     },
 
+    _filterSelection: function(items, selection) {
+        return _.filter(items, function(item) {
+            return item.value !== selection.value;
+        });
+    },
+
     _refreshPopupWithSearchHits: function(term){
         var matchingItems = this._filterItems(this.items, term);
         var hideSelectedItem = this.hideSelectedItem;
-        var selectedItem = this.selectedItem;
+        var selectedItem = this.getSelection();
         var itemsToShow;
 
         if(selectedItem && hideSelectedItem){
-            itemsToShow = _.filter(matchingItems, function(item) {
-                return item.value !== selectedItem.value;
-            });
+            itemsToShow = this._filterSelection(matchingItems, selectedItem);
         } else {
             itemsToShow = matchingItems;
         }

--- a/lib/MultiSelleckt.js
+++ b/lib/MultiSelleckt.js
@@ -76,6 +76,14 @@ MultiSelleckt.prototype._mutationHandler = function (mutations){
     });
 };
 
+MultiSelleckt.prototype._filterSelection = function (items, selection) {
+    var selectionValues = _.pluck(selection, 'value');
+
+    return _.filter(items, function(item) {
+        return selectionValues.indexOf(item.value) === -1;
+    });
+};
+
 MultiSelleckt.prototype.selectItem = function(item, options){
     options = options || {};
 

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -210,16 +210,20 @@ _.extend(SingleSelleckt.prototype, {
         }, []);
     },
 
+    _filterSelection: function(items, selection) {
+        return _.filter(items, function(item) {
+            return item.value !== selection.value;
+        });
+    },
+
     _refreshPopupWithSearchHits: function(term){
         var matchingItems = this._filterItems(this.items, term);
         var hideSelectedItem = this.hideSelectedItem;
-        var selectedItem = this.selectedItem;
+        var selectedItem = this.getSelection();
         var itemsToShow;
 
         if(selectedItem && hideSelectedItem){
-            itemsToShow = _.filter(matchingItems, function(item) {
-                return item.value !== selectedItem.value;
-            });
+            itemsToShow = this._filterSelection(matchingItems, selectedItem);
         } else {
             itemsToShow = matchingItems;
         }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "optionalDependencies": {},
   "browser": {
-    "jquery": "./test/lib/jquery-1.11.2.js"
+    "jquery": "./test/lib/jquery-1.11.2.js",
+    "Mustache": "./test/lib/mustache.js"
   },
   "browserify-shim": {
     "jquery": "global:$",

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -492,6 +492,31 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
             });
         });
 
+        describe('filtering', function(){
+            it('does not refresh the popup with this.selectedItems, if this.hideSelectedItem === true', function() {
+                multiSelleckt = new MultiSelleckt({
+                    multiple: true,
+                    $selectEl : $('<select multiple>' +
+                        '<option value="foo">foo</option>' +
+                        '<option value="bar">bar</option>' +
+                        '<option value="baz">baz</option>' +
+                        '</select>'),
+                    enableSearch: true,
+                    searchThreshold: 0,
+                    hideSelectedItem: true
+                });
+
+                multiSelleckt.render();
+                multiSelleckt.selectItemByValue('bar');
+                multiSelleckt._open();
+                multiSelleckt._refreshPopupWithSearchHits('ba');
+
+                expect(multiSelleckt.popup.$popup.find('.item').length).toEqual(1);
+                expect(multiSelleckt.popup.$popup.find('.item[data-value=bar]').length).toEqual(0);
+                expect(multiSelleckt.popup.$popup.find('.item[data-value=baz]').length).toEqual(1);
+            });
+        });
+
         describe('events', function(){
             beforeEach(function(){
                 multiSelleckt = new MultiSelleckt({

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,5 +1,5 @@
 'use strict';
 
-require('./specs/singleSelleckt.specs.js');
-require('./specs/multiSelleckt.specs.js');
-require('./specs/sellecktPopup.specs.js');
+require('./specs/SingleSelleckt.specs.js');
+require('./specs/MultiSelleckt.specs.js');
+require('./specs/SellecktPopup.specs.js');


### PR DESCRIPTION
When `hideSelectedItem` was set to `true` for MultiSelleckt the current selection would not show up in the dropdown. However, the selected values would suddenly appear in the dropdown when doing a search. Fix this so that MultiSelleckt behaves the same as SingleSelleckt.