### PR TITLE
Stopped the 'click' event propagation when an item/search field is clicked

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.selleckt=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.selleckt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 var KEY_CODES = {
@@ -610,6 +610,8 @@ _.extend(SellecktPopup.prototype, {
 
         $popup.on('click', function(e){
             var $target = $(e.target);
+
+            e.stopPropagation();
 
             if($target.is(itemClass) || $target.is(searchInputClass)){
                 return;

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.selleckt=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.selleckt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 var KEY_CODES = {
@@ -610,6 +610,8 @@ _.extend(SellecktPopup.prototype, {
 
         $popup.on('click', function(e){
             var $target = $(e.target);
+
+            e.stopPropagation();
 
             if($target.is(itemClass) || $target.is(searchInputClass)){
                 return;

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -299,6 +299,8 @@ _.extend(SellecktPopup.prototype, {
         $popup.on('click', function(e){
             var $target = $(e.target);
 
+            e.stopPropagation();
+
             if($target.is(itemClass) || $target.is(searchInputClass)){
                 return;
             }

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -561,6 +561,36 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
             });
         });
 
+        describe('clicking on the popup', function(){
+            var $opener;
+            var $body;
+            var clickHandlerSpy;
+
+            beforeEach(function() {
+                clickHandlerSpy = sandbox.spy();
+
+                $body = $('body');
+                $opener = $('<div>foo</div>', {
+                    'class': 'opener'
+                }).appendTo($body);
+
+                $body.on('click', clickHandlerSpy);
+            });
+
+            afterEach(function() {
+                $body.off('click', clickHandlerSpy);
+            });
+
+            it('does not propagate "click" events to the parent container', function() {
+                popup = new SellecktPopup({showSearch: true});
+                popup.open($opener, []);
+
+                popup.$popup.find('input.search').click();
+
+                expect(clickHandlerSpy.called).toBeFalsy();
+            });
+        });
+
         describe('closing the popup', function (){
             var $body;
 


### PR DESCRIPTION
Hi @grahamscott,
This code prevents the <code>click</code> event from bubbling up to <code>body</code> element.