### PR TITLE
Use `prop` instead of `attr` to check whether an option element is selected

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -914,12 +914,12 @@ _.extend(SingleSelleckt.prototype, {
                     data: $option.data()
                 };
 
-            if($option.attr('selected')){
-                memo.selectedItems.push(item);
-            }
-
             if(item.value && item.label){
                 memo.items.push(item);
+
+                if($option.prop('selected')){
+                    memo.selectedItems.push(item);
+                }
             }
 
             return memo;

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -914,12 +914,12 @@ _.extend(SingleSelleckt.prototype, {
                     data: $option.data()
                 };
 
-            if($option.attr('selected')){
-                memo.selectedItems.push(item);
-            }
-
             if(item.value && item.label){
                 memo.items.push(item);
+
+                if($option.prop('selected')){
+                    memo.selectedItems.push(item);
+                }
             }
 
             return memo;

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -242,12 +242,12 @@ _.extend(SingleSelleckt.prototype, {
                     data: $option.data()
                 };
 
-            if($option.attr('selected')){
-                memo.selectedItems.push(item);
-            }
-
             if(item.value && item.label){
                 memo.items.push(item);
+
+                if($option.prop('selected')){
+                    memo.selectedItems.push(item);
+                }
             }
 
             return memo;

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -219,6 +219,24 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(0).text()).toEqual('foo');
                 expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(1).text()).toEqual('baz');
             });
+
+            it('renders previously selected items in the multiselectItemTemplate when re-initializing selleckt', function(){
+                multiSelleckt.selectItemByValue(2);
+                expect(multiSelleckt.$sellecktEl.find('.selectionItem').length).toEqual(3);
+
+                multiSelleckt.destroy();
+                multiSelleckt = new MultiSelleckt({
+                    multiple: true,
+                    $selectEl : $el
+                });
+                multiSelleckt.render();
+
+                expect(multiSelleckt.$sellecktEl.find('.selectionItem').length).toEqual(3);
+                expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(0).text()).toEqual('foo');
+                expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(1).text()).toEqual('bar');
+                expect(multiSelleckt.$sellecktEl.find('.'+multiSelleckt.selectionItemClass).eq(2).text()).toEqual('baz');
+            });
+
             it('attaches the item to the selectedItem dom element', function(){
                 var selectedItems = multiSelleckt.getSelection();
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -229,12 +229,45 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                         expect(selleckt.items[1].value).toEqual('3');
                         expect(selleckt.items[1].label).toEqual('baz');
                     });
+                    it('does not store selected options as this.selectedItem when they don\'t have a label', function(){
+                        var selectHtml = '<select>' +
+                            '<option selected></option>' +
+                            '<option value="1">foo</option>' +
+                            '</select>';
+
+                        selleckt.destroy();
+
+                        var $newEl = $(selectHtml).appendTo($testArea);
+
+                        selleckt = new SingleSelleckt({
+                            $selectEl : $newEl
+                        });
+
+                        expect(selleckt.selectedItem).toBeUndefined();
+                    });
+                    it('does not store selected options as this.selectedItem when they don\'t have a value', function(){
+                        var selectHtml = '<select>' +
+                            '<option selected value="">-- Please Select --</option>' +
+                            '<option value="1">foo</option>' +
+                            '</select>';
+
+                        selleckt.destroy();
+
+                        var $newEl = $(selectHtml).appendTo($testArea);
+
+                        selleckt = new SingleSelleckt({
+                            $selectEl : $newEl
+                        });
+
+                        expect(selleckt.selectedItem).toBeUndefined();
+                    });
 
                     describe('when there is no selected item already', function(){
                         var $newEl;
 
                         beforeEach(function(){
                             var selectHtml = '<select>' +
+                            '<option></option>' +
                             '<option value="1">foo</option>' +
                             '<option value="2">bar</option>' +
                             '<option value="3">baz</option>' +
@@ -332,6 +365,21 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
             it('renders the selected element based on this.template', function(){
                 expect(selleckt.$sellecktEl.find('.selected').length).toEqual(1);
+            });
+
+            it('renders previously selected element based on this.template when re-initializing selleckt', function(){
+                selleckt.selectItemByValue(3);
+                expect(selleckt.selectedItem.value).toEqual('3');
+
+                selleckt.destroy();
+                selleckt = new SingleSelleckt({
+                    $selectEl : $el
+                });
+                selleckt.render();
+
+                expect(selleckt.$sellecktEl.find('.selected').length).toEqual(1);
+                expect(selleckt.selectedItem.value).toEqual('3');
+                expect(selleckt.selectedItem.label).toEqual('baz');
             });
 
             it('renders the selected text element based on this.template', function(){


### PR DESCRIPTION
Currently, when selleckt is re-initialized on a `select` element *after* the user has modified the selection then re-initializing will cause selleckt to display the wrong selected items (it displays the select's initial state rather than the user's selection).

This is caused by checking the selected state of option elements via `attr` rather than `prop`. 