### PR TITLE
Support for aliases in selleckt

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -70,9 +70,9 @@ var TEMPLATES = require('./TEMPLATES');
 var templateUtils = require('./templateUtils');
 var SingleSelleckt = require('./SingleSelleckt.js');
 
-var $ = (typeof window !== "undefined" ? window.$ : typeof global !== "undefined" ? global.$ : null);
-var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
-var Mustache = (typeof window !== "undefined" ? window.Mustache : typeof global !== "undefined" ? global.Mustache : null);
+var $ = (typeof window !== "undefined" ? window['$'] : typeof global !== "undefined" ? global['$'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
+var Mustache = (typeof window !== "undefined" ? window['Mustache'] : typeof global !== "undefined" ? global['Mustache'] : null);
 
 function MultiSelleckt(options){
     var settings = _.defaults(options, {
@@ -316,9 +316,9 @@ var KEY_CODES = require('./KEY_CODES');
 var TEMPLATES = require('./TEMPLATES');
 var templateUtils = require('./templateUtils');
 
-var $ = (typeof window !== "undefined" ? window.$ : typeof global !== "undefined" ? global.$ : null);
-var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
-var Mustache = (typeof window !== "undefined" ? window.Mustache : typeof global !== "undefined" ? global.Mustache : null);
+var $ = (typeof window !== "undefined" ? window['$'] : typeof global !== "undefined" ? global['$'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
+var Mustache = (typeof window !== "undefined" ? window['Mustache'] : typeof global !== "undefined" ? global['Mustache'] : null);
 var MicroEvent = require('./MicroEvent');
 
 function createPopup(){
@@ -677,9 +677,9 @@ var TEMPLATES = require('./TEMPLATES');
 var templateUtils = require('./templateUtils');
 var SellecktPopup = require('./SellecktPopup');
 
-var $ = (typeof window !== "undefined" ? window.$ : typeof global !== "undefined" ? global.$ : null);
-var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
-var Mustache = (typeof window !== "undefined" ? window.Mustache : typeof global !== "undefined" ? global.Mustache : null);
+var $ = (typeof window !== "undefined" ? window['$'] : typeof global !== "undefined" ? global['$'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
+var Mustache = (typeof window !== "undefined" ? window['Mustache'] : typeof global !== "undefined" ? global['Mustache'] : null);
 var MicroEvent = require('./MicroEvent');
 
 function SingleSelleckt(options){
@@ -851,35 +851,56 @@ _.extend(SingleSelleckt.prototype, {
         this.selectItem(item);
     },
 
-    _filterItems: function(items, term){
-        var matchTerm;
+    _filterItems: function(items, term) {
+        var matchTerm, reduced;
 
-        if(!term){
+        if (!term) {
             return items;
         }
 
         matchTerm = term.toLowerCase();
 
-        return _.reduce(items, function(memo, item){
+        reduced = _.reduce(items, function(memo, item) {
             var matchIndex;
+            var group = 'byName';
+            var matchStart;
+            var matchEnd;
 
             if (!item.value) {
                 return memo;
             }
 
             matchIndex = item.label.toLowerCase().indexOf(matchTerm);
+            matchStart = matchIndex;
+            matchEnd = matchIndex + (term.length - 1);
 
-            if(matchIndex === -1){
-                return memo;
+            if (matchIndex === -1 && item.aliases && item.aliases.length > 0) {
+                // try the aliases
+                matchIndex = _.reduce(item.aliases, function(index, alias) {
+                    if (index === -1) {
+                        return String(alias).toLowerCase().indexOf(matchTerm);
+                    } else {
+                        return index;
+                    }
+                }, -1);
+
+                if (matchIndex !== -1) {
+                    group = 'byAlias';
+                    matchStart = matchEnd = -1;
+                }
             }
 
-            memo.push(_.extend({}, item, {
-                matchStart: matchIndex,
-                matchEnd: matchIndex + (term.length - 1)
-            }));
+            if (matchIndex !== -1) {
+                memo[group].push(_.extend({}, item, {
+                    matchStart: matchStart,
+                    matchEnd: matchEnd
+                }));
+            }
 
             return memo;
-        }, []);
+        }, {byName: [], byAlias: []});
+
+        return reduced.byName.concat(reduced.byAlias);
     },
 
     _filterSelection: function(items, selection) {
@@ -908,11 +929,16 @@ _.extend(SingleSelleckt.prototype, {
     _parseItemsFromOptions: function($selectEl){
         return _.reduce($selectEl.find('option'), function(memo, option){
             var $option = $(option),
+                data = $option.data(),
                 item = {
                     value: $option.val(),
                     label: $option.text(),
-                    data: $option.data()
+                    data: data
                 };
+
+            if (data && data.aliases) {
+                item.aliases = data.aliases.split(',');
+            }
 
             if(item.value && item.label){
                 memo.items.push(item);
@@ -938,7 +964,10 @@ _.extend(SingleSelleckt.prototype, {
 
         if(item.data){
             Object.keys(item.data).forEach(function(key){
-                $option.attr('data-' + key, item.data[key]);
+                var val = item.data[key];
+                var attrVal = _.isArray(val) ? val.join(',') : val;
+
+                $option.attr('data-' + key, attrVal);
             });
         }
 
@@ -947,11 +976,18 @@ _.extend(SingleSelleckt.prototype, {
 
     _getItemsFromNodes: function(nodeList){
         return _.map(nodeList, function(node){
-            return {
+            var aliases = node.getAttribute('data-aliases');
+            var item = {
                 value: node.value,
                 label: node.text,
                 isSelected: node.selected || undefined
             };
+
+            if (aliases) {
+                item.aliases = aliases.split(',');
+            }
+
+            return item;
         });
     },
 
@@ -1299,8 +1335,8 @@ module.exports = selleckt;
 (function (global){
 'use strict';
 
-var $ = (typeof window !== "undefined" ? window.$ : typeof global !== "undefined" ? global.$ : null);
-var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
+var $ = (typeof window !== "undefined" ? window['$'] : typeof global !== "undefined" ? global['$'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
 
 module.exports = {
     mixin: function(selleckt){
@@ -1339,7 +1375,7 @@ module.exports = {
 */
 
 var selleckt = require('../selleckt');
-var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
 
 function objectIntersect(arr1, arr2){
     return _.filter(arr1, function(item){
@@ -1462,7 +1498,7 @@ module.exports = selleckt;
 (function (global){
 'use strict';
 
-var Mustache = (typeof window !== "undefined" ? window.Mustache : typeof global !== "undefined" ? global.Mustache : null);
+var Mustache = (typeof window !== "undefined" ? window['Mustache'] : typeof global !== "undefined" ? global['Mustache'] : null);
 
 module.exports = {
     cacheTemplate: function(template) {

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -179,35 +179,56 @@ _.extend(SingleSelleckt.prototype, {
         this.selectItem(item);
     },
 
-    _filterItems: function(items, term){
-        var matchTerm;
+    _filterItems: function(items, term) {
+        var matchTerm, reduced;
 
-        if(!term){
+        if (!term) {
             return items;
         }
 
         matchTerm = term.toLowerCase();
 
-        return _.reduce(items, function(memo, item){
+        reduced = _.reduce(items, function(memo, item) {
             var matchIndex;
+            var group = 'byName';
+            var matchStart;
+            var matchEnd;
 
             if (!item.value) {
                 return memo;
             }
 
             matchIndex = item.label.toLowerCase().indexOf(matchTerm);
+            matchStart = matchIndex;
+            matchEnd = matchIndex + (term.length - 1);
 
-            if(matchIndex === -1){
-                return memo;
+            if (matchIndex === -1 && item.aliases && item.aliases.length > 0) {
+                // try the aliases
+                matchIndex = _.reduce(item.aliases, function(index, alias) {
+                    if (index === -1) {
+                        return String(alias).toLowerCase().indexOf(matchTerm);
+                    } else {
+                        return index;
+                    }
+                }, -1);
+
+                if (matchIndex !== -1) {
+                    group = 'byAlias';
+                    matchStart = matchEnd = -1;
+                }
             }
 
-            memo.push(_.extend({}, item, {
-                matchStart: matchIndex,
-                matchEnd: matchIndex + (term.length - 1)
-            }));
+            if (matchIndex !== -1) {
+                memo[group].push(_.extend({}, item, {
+                    matchStart: matchStart,
+                    matchEnd: matchEnd
+                }));
+            }
 
             return memo;
-        }, []);
+        }, {byName: [], byAlias: []});
+
+        return reduced.byName.concat(reduced.byAlias);
     },
 
     _filterSelection: function(items, selection) {
@@ -236,11 +257,16 @@ _.extend(SingleSelleckt.prototype, {
     _parseItemsFromOptions: function($selectEl){
         return _.reduce($selectEl.find('option'), function(memo, option){
             var $option = $(option),
+                data = $option.data(),
                 item = {
                     value: $option.val(),
                     label: $option.text(),
-                    data: $option.data()
+                    data: data
                 };
+
+            if (data && data.aliases) {
+                item.aliases = data.aliases.split(',');
+            }
 
             if(item.value && item.label){
                 memo.items.push(item);
@@ -266,7 +292,10 @@ _.extend(SingleSelleckt.prototype, {
 
         if(item.data){
             Object.keys(item.data).forEach(function(key){
-                $option.attr('data-' + key, item.data[key]);
+                var val = item.data[key];
+                var attrVal = _.isArray(val) ? val.join(',') : val;
+
+                $option.attr('data-' + key, attrVal);
             });
         }
 
@@ -275,11 +304,18 @@ _.extend(SingleSelleckt.prototype, {
 
     _getItemsFromNodes: function(nodeList){
         return _.map(nodeList, function(node){
-            return {
+            var aliases = node.getAttribute('data-aliases');
+            var item = {
                 value: node.value,
                 label: node.text,
                 isSelected: node.selected || undefined
             };
+
+            if (aliases) {
+                item.aliases = aliases.split(',');
+            }
+
+            return item;
         });
     },
 

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -6,7 +6,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             elHtml =
                 '<select>' +
                     '<option selected value="1">foo</option>' +
-                    '<option value="2" data-meh="whee" data-bah="oink">bar</option>' +
+                    '<option value="2" data-meh="whee" data-bah="oink" data-aliases="foo,bar">bar</option>' +
                     '<option value="3">baz</option>' +
                 '</select>',
             $testArea,
@@ -192,11 +192,20 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                         expect(_.size(selleckt.items[0].data)).toEqual(0);
 
                         expect(selleckt.items[1].data).toBeDefined();
-                        expect(_.size(selleckt.items[1].data)).toEqual(2);
+                        expect(_.size(selleckt.items[1].data)).toEqual(3);
                         expect(selleckt.items[1].data).toEqual({
                             meh: 'whee',
-                            bah: 'oink'
+                            bah: 'oink',
+                            aliases: 'foo,bar'
                         });
+                    });
+                    it('parses aliases into .aliases property', function(){
+                        expect(selleckt.items[0].aliases).toBeUndefined();
+                        expect(_.size(selleckt.items[0].data)).toEqual(0);
+
+                        expect(selleckt.items[1].aliases).toBeDefined();
+                        expect(_.size(selleckt.items[1].data)).toEqual(3);
+                        expect(selleckt.items[1].aliases).toEqual(['foo', 'bar']);
                     });
                     it('stores the selected option as this.selectedItem', function(){
                         expect(selleckt.selectedItem).toBeDefined();
@@ -911,8 +920,10 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                     label: 'bar',
                     data: {
                         bah: 'oink',
-                        meh: 'whee'
-                    }
+                        meh: 'whee',
+                        aliases: 'foo,bar'
+                    },
+                    aliases: ['foo', 'bar']
                 });
 
                 popup.trigger('valueSelected', '1');
@@ -1200,6 +1211,31 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                     { label: 'bar', value: 'bar', matchStart: 0, matchEnd: 1 },
                     { label: 'baz', value: 'baz', matchStart: 0, matchEnd: 1 },
                     { label: 'foobaz', value: 'foobaz', matchStart: 3, matchEnd: 4 }
+                ]);
+            });
+
+            it('performs a search in aliases if they are there, placing found by alias at the end', function(){
+                var selleckt = new SingleSelleckt({
+                    $selectEl: $('<select>')
+                });
+
+                selleckt.items = [
+                    {label: 'foo', value: 'foo', aliases: ['baaar']},
+                    {label: 'foo2', value: 'foo2', aliases: ['ohno', 'FOOBAR']},
+                    {label: 'bar', value: 'bar'},
+                    {label: 'baz', value: 'baz'},
+                    {label: 'foofoo', value: 'foofoo'},
+                    {label: 'foobaz', value: 'foobaz'}
+                ];
+
+                var filteredItems = selleckt._filterItems(selleckt.items, 'BA');
+
+                expect(filteredItems).toEqual([
+                    { label: 'bar', value: 'bar', matchStart: 0, matchEnd: 1 },
+                    { label: 'baz', value: 'baz', matchStart: 0, matchEnd: 1 },
+                    { label: 'foobaz', value: 'foobaz', matchStart: 3, matchEnd: 4 },
+                    { label: 'foo', value: 'foo', aliases: ['baaar'], matchStart: -1, matchEnd: -1 },
+                    { label: 'foo2', value: 'foo2', aliases: ['ohno', 'FOOBAR'], matchStart: -1, matchEnd: -1 }
                 ]);
             });
 


### PR DESCRIPTION
Adds support for (optional) multiple aliases for each of the `selleckt` option items.
Useful for filtering where an alias can't be part of an option label but should still match the search input.