### PR TITLE
When not enough space for dropdown on either side, prefer bottom placement, not top

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -620,18 +620,30 @@ _.extend(SellecktPopup.prototype, {
         });
     },
 
+    _canShowBelow: function(options, openerHeight, openerOffset) {
+        var $window = $(window),
+            popupHeight = this.$popup.outerHeight(),
+            windowHeight = $window.height(),
+            windowScrollTop = $window.scrollTop(),
+            viewportBottom = windowScrollTop + windowHeight,
+            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
+            enoughRoomAbove = openerOffset.top >= popupHeight;
+
+        // when there's no space anywhere, prefer bottom placement
+        if (!enoughRoomAbove) {
+            enoughRoomBelow = true;
+        }
+
+        return enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped'));
+    },
+
     _positionPopup: function($opener, options){
         options = options || {};
 
-        var $window = $(window),
-            windowHeight = $window.height(),
-            windowScrollTop = $window.scrollTop(),
-            popupHeight = this.$popup.outerHeight(),
+        var popupHeight = this.$popup.outerHeight(),
             openerHeight = $opener.outerHeight(),
             openerOffset = $opener.offset(),
-            viewportBottom = windowScrollTop + windowHeight,
-            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
-            showBelow = enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped')),
+            showBelow = this._canShowBelow(options, openerHeight, openerOffset),
             css = {
                 position: 'absolute',
                 left: openerOffset.left,

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -620,18 +620,30 @@ _.extend(SellecktPopup.prototype, {
         });
     },
 
+    _canShowBelow: function(options, openerHeight, openerOffset) {
+        var $window = $(window),
+            popupHeight = this.$popup.outerHeight(),
+            windowHeight = $window.height(),
+            windowScrollTop = $window.scrollTop(),
+            viewportBottom = windowScrollTop + windowHeight,
+            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
+            enoughRoomAbove = openerOffset.top >= popupHeight;
+
+        // when there's no space anywhere, prefer bottom placement
+        if (!enoughRoomAbove) {
+            enoughRoomBelow = true;
+        }
+
+        return enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped'));
+    },
+
     _positionPopup: function($opener, options){
         options = options || {};
 
-        var $window = $(window),
-            windowHeight = $window.height(),
-            windowScrollTop = $window.scrollTop(),
-            popupHeight = this.$popup.outerHeight(),
+        var popupHeight = this.$popup.outerHeight(),
             openerHeight = $opener.outerHeight(),
             openerOffset = $opener.offset(),
-            viewportBottom = windowScrollTop + windowHeight,
-            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
-            showBelow = enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped')),
+            showBelow = this._canShowBelow(options, openerHeight, openerOffset),
             css = {
                 position: 'absolute',
                 left: openerOffset.left,

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -308,18 +308,30 @@ _.extend(SellecktPopup.prototype, {
         });
     },
 
+    _canShowBelow: function(options, openerHeight, openerOffset) {
+        var $window = $(window),
+            popupHeight = this.$popup.outerHeight(),
+            windowHeight = $window.height(),
+            windowScrollTop = $window.scrollTop(),
+            viewportBottom = windowScrollTop + windowHeight,
+            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
+            enoughRoomAbove = openerOffset.top >= popupHeight;
+
+        // when there's no space anywhere, prefer bottom placement
+        if (!enoughRoomAbove) {
+            enoughRoomBelow = true;
+        }
+
+        return enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped'));
+    },
+
     _positionPopup: function($opener, options){
         options = options || {};
 
-        var $window = $(window),
-            windowHeight = $window.height(),
-            windowScrollTop = $window.scrollTop(),
-            popupHeight = this.$popup.outerHeight(),
+        var popupHeight = this.$popup.outerHeight(),
             openerHeight = $opener.outerHeight(),
             openerOffset = $opener.offset(),
-            viewportBottom = windowScrollTop + windowHeight,
-            enoughRoomBelow = viewportBottom > (openerOffset.top + openerHeight + popupHeight),
-            showBelow = enoughRoomBelow && !(options.keepCurrentOrientation && this.$popup.hasClass('flipped')),
+            showBelow = this._canShowBelow(options, openerHeight, openerOffset),
             css = {
                 position: 'absolute',
                 left: openerOffset.left,

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -691,6 +691,14 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
 
                 expect(popup.$popup.hasClass('flipped')).toEqual(true);
             });
+
+            it('if there is no place on either side, prefers bottom placement', function(){
+                $opener.css({top :0, height: $(window).height()});
+
+                popup.open($opener, items);
+
+                expect(popup.$popup.hasClass('flipped')).toEqual(false);
+            });
         });
 
         describe('Keyboard input - items', function(){


### PR DESCRIPTION
On a tiny screen with a very long list of items in a `selleckt` dropdown, there is sometimes not enough vertical space on either side of an `opener` to display the full list of items. In this case, a dropdown should be positioned on the bottom as browsers are more likely to provide extra scrolling in that case.