### PR TITLE
Drop IE8 support: remove IE8 from SauceLabs launchers.

### DIFF
--- a/karma.conf-saucelabs-legacyselleckt.js
+++ b/karma.conf-saucelabs-legacyselleckt.js
@@ -19,11 +19,6 @@ module.exports = function(config) {
             base: 'SauceLabs',
             browserName: 'internet explorer',
             version: '9.0'
-        },
-        'SL_IE_8': {
-            base: 'SauceLabs',
-            browserName: 'internet explorer',
-            version: '8.0'
         }
     };
 


### PR DESCRIPTION
> The pull request removes IE8 from the list of SauceLabs launchers.

IE8 won't be supported any more by legacy-selleckt. Currently the demo pages show that at  it still works. The compatibility won't however be actively developed.

The tests however fail on IE8 with an error regarding the positioning.

<img width="547" alt="screen shot 2016-05-24 at 14 16 43" src="https://cloud.githubusercontent.com/assets/1877073/15504355/d89502e0-21be-11e6-84b6-fd6402527b59.png">

Furthermore IE8 throws an error with `'this.$popup' is null or not an object` at `selleckt-legacy.js:643`.