### PR TITLE
Add jQuery 3.0.0 compat layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ An example of using an event, where there is a select with id 'foo' to which sel
 ```javascript
 var sellecktInstance = $('#foo').data('selleckt');
 
-sellecktInstance.bind('itemSelected', function onItemSelected(item){
+sellecktInstance.on('itemSelected', function onItemSelected(item){
     console.log('Item selected: ', item);
 });
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -217,7 +217,7 @@ $select3.data('selleckt').$sellecktEl.on('click', '.add', function(e){
                     {label: 'Baz', value:'3', customAttr: 'Z'}
                 ]);
 
-                $select4.data('selleckt').bind('onPopupCreated', function(popup){
+                $select4.data('selleckt').on('onPopupCreated', function(popup){
                     popup.$popup.on('click', '.add', function(e){
                         e.preventDefault();
                         e.stopPropagation();

--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -25,22 +25,28 @@ module.exports = KEY_CODES;
 */
 'use strict';
 
-var MicroEvent  = function(){};
+var MicroEvent = function(){};
 MicroEvent.prototype = {
-    bind    : function(event, fct){
+    bind: function(event, fct){
         this._events = this._events || {};
-        this._events[event] = this._events[event]   || [];
+        this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    unbind  : function(event, fct){
+    on: this.bind,
+    unbind: function(event, fct){
         this._events = this._events || {};
-        if( event in this._events === false  ) { return; }
+        if (event in this._events === false) {
+            return;
+        }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    trigger : function(event /* , args... */){
+    off: this.unbind,
+    trigger: function(event /* , args... */){
         this._events = this._events || {};
-        if( event in this._events === false  ) { return; }
-        for(var i = 0; i < this._events[event].length; i++){
+        if (event in this._events === false) {
+            return;
+        }
+        for (var i = 0; i < this._events[event].length; i++) {
             this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
         }
     }
@@ -54,9 +60,9 @@ MicroEvent.prototype = {
  * @param {Object} the object which will support MicroEvent
 */
 MicroEvent.mixin = function(destObject){
-    var props  = ['bind', 'unbind', 'trigger'];
-    for(var i = 0; i < props.length; i ++){
-        destObject.prototype[props[i]]  = MicroEvent.prototype[props[i]];
+    var props = ['bind', 'on', 'unbind', 'off', 'trigger'];
+    for (var i = 0; i < props.length; i++) {
+        destObject.prototype[props[i]] = MicroEvent.prototype[props[i]];
     }
 };
 

--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -32,7 +32,10 @@ MicroEvent.prototype = {
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    bind: this.on,
+    bind: function() {
+        console.warn('SELLECKT: .bind() is deprecated. Use .on() instead.');
+        this.on.apply(this, arguments);
+    },
     off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -40,7 +43,10 @@ MicroEvent.prototype = {
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    unbind: this.off,
+    unbind: function() {
+        console.warn('SELLECKT: .unbind() is deprecated. Use .off() instead.');
+        this.off.apply(this, arguments);
+    },
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {

--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -27,20 +27,20 @@ module.exports = KEY_CODES;
 
 var MicroEvent = function(){};
 MicroEvent.prototype = {
-    bind: function(event, fct){
+    on: function(event, fct){
         this._events = this._events || {};
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    on: this.bind,
-    unbind: function(event, fct){
+    bind: this.on,
+    off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
             return;
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    off: this.unbind,
+    unbind: this.off,
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -829,7 +829,7 @@ _.extend(SingleSelleckt.prototype, {
 
     _removePopup: function() {
         if (this.popup) {
-            this.popup.unbind('valueSelected', this.onPopupValueSelected);
+            this.popup.off('valueSelected', this.onPopupValueSelected);
             this.popup.close();
             this.popup = undefined;
         }
@@ -866,9 +866,9 @@ _.extend(SingleSelleckt.prototype, {
 
         popup.open(this.$sellecktEl.find('.' + this.selectedClass), this.getItemsForPopup(), popupOptions);
 
-        popup.bind('close', _.bind(this._onPopupClose, this));
-        popup.bind('valueSelected', _.bind(this._onPopupValueSelected, this));
-        popup.bind('search', _.bind(this._refreshPopupWithSearchHits, this));
+        popup.on('close', _.bind(this._onPopupClose, this));
+        popup.on('valueSelected', _.bind(this._onPopupValueSelected, this));
+        popup.on('search', _.bind(this._refreshPopupWithSearchHits, this));
 
         this.trigger('onPopupCreated', popup);
 

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -25,22 +25,28 @@ module.exports = KEY_CODES;
 */
 'use strict';
 
-var MicroEvent  = function(){};
+var MicroEvent = function(){};
 MicroEvent.prototype = {
-    bind    : function(event, fct){
+    bind: function(event, fct){
         this._events = this._events || {};
-        this._events[event] = this._events[event]   || [];
+        this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    unbind  : function(event, fct){
+    on: this.bind,
+    unbind: function(event, fct){
         this._events = this._events || {};
-        if( event in this._events === false  ) { return; }
+        if (event in this._events === false) {
+            return;
+        }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    trigger : function(event /* , args... */){
+    off: this.unbind,
+    trigger: function(event /* , args... */){
         this._events = this._events || {};
-        if( event in this._events === false  ) { return; }
-        for(var i = 0; i < this._events[event].length; i++){
+        if (event in this._events === false) {
+            return;
+        }
+        for (var i = 0; i < this._events[event].length; i++) {
             this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
         }
     }
@@ -54,9 +60,9 @@ MicroEvent.prototype = {
  * @param {Object} the object which will support MicroEvent
 */
 MicroEvent.mixin = function(destObject){
-    var props  = ['bind', 'unbind', 'trigger'];
-    for(var i = 0; i < props.length; i ++){
-        destObject.prototype[props[i]]  = MicroEvent.prototype[props[i]];
+    var props = ['bind', 'on', 'unbind', 'off', 'trigger'];
+    for (var i = 0; i < props.length; i++) {
+        destObject.prototype[props[i]] = MicroEvent.prototype[props[i]];
     }
 };
 

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -32,7 +32,10 @@ MicroEvent.prototype = {
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    bind: this.on,
+    bind: function() {
+        console.warn('SELLECKT: .bind() is deprecated. Use .on() instead.');
+        this.on.apply(this, arguments);
+    },
     off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -40,7 +43,10 @@ MicroEvent.prototype = {
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    unbind: this.off,
+    unbind: function() {
+        console.warn('SELLECKT: .unbind() is deprecated. Use .off() instead.');
+        this.off.apply(this, arguments);
+    },
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -27,20 +27,20 @@ module.exports = KEY_CODES;
 
 var MicroEvent = function(){};
 MicroEvent.prototype = {
-    bind: function(event, fct){
+    on: function(event, fct){
         this._events = this._events || {};
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    on: this.bind,
-    unbind: function(event, fct){
+    bind: this.on,
+    off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
             return;
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    off: this.unbind,
+    unbind: this.off,
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -829,7 +829,7 @@ _.extend(SingleSelleckt.prototype, {
 
     _removePopup: function() {
         if (this.popup) {
-            this.popup.unbind('valueSelected', this.onPopupValueSelected);
+            this.popup.off('valueSelected', this.onPopupValueSelected);
             this.popup.close();
             this.popup = undefined;
         }
@@ -866,9 +866,9 @@ _.extend(SingleSelleckt.prototype, {
 
         popup.open(this.$sellecktEl.find('.' + this.selectedClass), this.getItemsForPopup(), popupOptions);
 
-        popup.bind('close', _.bind(this._onPopupClose, this));
-        popup.bind('valueSelected', _.bind(this._onPopupValueSelected, this));
-        popup.bind('search', _.bind(this._refreshPopupWithSearchHits, this));
+        popup.on('close', _.bind(this._onPopupClose, this));
+        popup.on('valueSelected', _.bind(this._onPopupValueSelected, this));
+        popup.on('search', _.bind(this._refreshPopupWithSearchHits, this));
 
         this.trigger('onPopupCreated', popup);
 

--- a/lib/MicroEvent.js
+++ b/lib/MicroEvent.js
@@ -19,7 +19,10 @@ MicroEvent.prototype = {
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    bind: this.on,
+    bind: function() {
+        console.warn('SELLECKT: .bind() is deprecated. Use .on() instead.');
+        this.on.apply(this, arguments);
+    },
     off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -27,7 +30,10 @@ MicroEvent.prototype = {
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
-    unbind: this.off,
+    unbind: function() {
+        console.warn('SELLECKT: .unbind() is deprecated. Use .off() instead.');
+        this.off.apply(this, arguments);
+    },
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {

--- a/lib/MicroEvent.js
+++ b/lib/MicroEvent.js
@@ -14,18 +14,20 @@
 
 var MicroEvent = function(){};
 MicroEvent.prototype = {
-    bind: function(event, fct){
+    on: function(event, fct){
         this._events = this._events || {};
         this._events[event] = this._events[event] || [];
         this._events[event].push(fct);
     },
-    unbind: function(event, fct){
+    bind: this.on,
+    off: function(event, fct){
         this._events = this._events || {};
         if (event in this._events === false) {
             return;
         }
         this._events[event].splice(this._events[event].indexOf(fct), 1);
     },
+    unbind: this.off,
     trigger: function(event /* , args... */){
         this._events = this._events || {};
         if (event in this._events === false) {
@@ -45,7 +47,7 @@ MicroEvent.prototype = {
  * @param {Object} the object which will support MicroEvent
 */
 MicroEvent.mixin = function(destObject){
-    var props = ['bind', 'unbind', 'trigger'];
+    var props = ['bind', 'on', 'unbind', 'off', 'trigger'];
     for (var i = 0; i < props.length; i++) {
         destObject.prototype[props[i]] = MicroEvent.prototype[props[i]];
     }

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -123,7 +123,7 @@ _.extend(SingleSelleckt.prototype, {
 
     _removePopup: function() {
         if (this.popup) {
-            this.popup.unbind('valueSelected', this.onPopupValueSelected);
+            this.popup.off('valueSelected', this.onPopupValueSelected);
             this.popup.close();
             this.popup = undefined;
         }
@@ -160,9 +160,9 @@ _.extend(SingleSelleckt.prototype, {
 
         popup.open(this.$sellecktEl.find('.' + this.selectedClass), this.getItemsForPopup(), popupOptions);
 
-        popup.bind('close', _.bind(this._onPopupClose, this));
-        popup.bind('valueSelected', _.bind(this._onPopupValueSelected, this));
-        popup.bind('search', _.bind(this._refreshPopupWithSearchHits, this));
+        popup.on('close', _.bind(this._onPopupClose, this));
+        popup.on('valueSelected', _.bind(this._onPopupValueSelected, this));
+        popup.on('search', _.bind(this._refreshPopupWithSearchHits, this));
 
         this.trigger('onPopupCreated', popup);
 

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -359,7 +359,7 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
             it('does not trigger an "itemSelected" event when option.silent is passed', function(){
                 var spy = sandbox.spy();
 
-                multiSelleckt.bind('trigger', spy);
+                multiSelleckt.on('trigger', spy);
 
                 multiSelleckt.selectItem(1, {silent: true});
 
@@ -504,7 +504,7 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
             it('triggers an "itemUnselected" event with the removed item', function(){
                 var spy = sandbox.spy();
 
-                multiSelleckt.bind('itemUnselected', spy);
+                multiSelleckt.on('itemUnselected', spy);
                 $clickTarget.trigger('click');
 
                 expect(spy.calledOnce).toEqual(true);

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -635,7 +635,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
             it('triggers a close event', function(){
                 var spy = sandbox.spy();
 
-                popup.bind('close', spy);
+                popup.on('close', spy);
                 popup.close();
 
                 expect(spy.calledOnce).toEqual(true);
@@ -803,7 +803,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                 var spy = sandbox.spy();
                 var $firstItem = $popup.find('.' + popup.itemClass).first();
 
-                popup.bind('valueSelected', spy);
+                popup.on('valueSelected', spy);
 
                 $firstItem.addClass(popup.highlightClass);
                 $firstItem.trigger($.Event('keydown', {
@@ -935,7 +935,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                     O: 79
                 };
 
-                popup.bind('search', searchSpy);
+                popup.on('search', searchSpy);
 
                 $searchInput.val('foo');
                 $searchInput.trigger($.Event('keyup', {

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -713,12 +713,12 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             it('triggers a "close" event when _close is called', function(){
                 var listener = sinon.stub();
 
-                selleckt.bind('close', listener);
+                selleckt.on('close', listener);
                 selleckt._close();
 
                 expect(listener.calledOnce).toEqual(true);
 
-                selleckt.unbind('close', listener);
+                selleckt.off('close', listener);
             });
 
             it('adds a class of "open" to this.$sellecktEl when the selleckt is opened', function(){
@@ -949,7 +949,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             it('triggers an "itemSelected" event with this.selectedItem', function(){
                 var spy = sandbox.spy();
 
-                selleckt.bind('itemSelected', spy);
+                selleckt.on('itemSelected', spy);
 
                 popup.trigger('valueSelected', '2');
 
@@ -960,7 +960,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
             it('does not trigger an "itemSelected" event when option.silent is passed', function(){
                 var spy = sandbox.spy();
 
-                selleckt.bind('trigger', spy);
+                selleckt.on('trigger', spy);
 
                 selleckt.selectItem(1, {silent: true});
 
@@ -972,7 +972,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
                 popup.trigger('valueSelected', '1');
 
-                selleckt.bind('itemSelected', spy);
+                selleckt.on('itemSelected', spy);
 
                 popup.trigger('valueSelected', '1');
                 expect(spy.called).toEqual(false);
@@ -1277,7 +1277,7 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 selleckt.render();
                 selleckt._open();
 
-                selleckt.bind('optionsFiltered', spy);
+                selleckt.on('optionsFiltered', spy);
 
                 selleckt._refreshPopupWithSearchHits('ba');
 


### PR DESCRIPTION
In this PR:

- `$#bind` and `$#unbind` are deprecated in jQuery 3, so I added `on` and `off` aliases to `MicroEvent#bind` and `#unbind` for consistency sake

More details: 
https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnbind-is-deprecated