### PR TITLE
Do not trigger itemUnselected when options.silent is passed

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -300,13 +300,12 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
         this.$sellecktEl.find('.' + this.selectedTextClass).text(this.placeholderText);
     }
 
-    if (!options.silent) {
-        this.updateOriginalSelect();
-    }
-
     this.toggleDisabled();
 
-    this.trigger('itemUnselected', item);
+    if (!options.silent) {
+        this.updateOriginalSelect();
+        this.trigger('itemUnselected', item);
+    }
 };
 
 MultiSelleckt.prototype.toggleDisabled = function(){

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -300,13 +300,12 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
         this.$sellecktEl.find('.' + this.selectedTextClass).text(this.placeholderText);
     }
 
-    if (!options.silent) {
-        this.updateOriginalSelect();
-    }
-
     this.toggleDisabled();
 
-    this.trigger('itemUnselected', item);
+    if (!options.silent) {
+        this.updateOriginalSelect();
+        this.trigger('itemUnselected', item);
+    }
 };
 
 MultiSelleckt.prototype.toggleDisabled = function(){

--- a/lib/MultiSelleckt.js
+++ b/lib/MultiSelleckt.js
@@ -222,13 +222,12 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
         this.$sellecktEl.find('.' + this.selectedTextClass).text(this.placeholderText);
     }
 
-    if (!options.silent) {
-        this.updateOriginalSelect();
-    }
-
     this.toggleDisabled();
 
-    this.trigger('itemUnselected', item);
+    if (!options.silent) {
+        this.updateOriginalSelect();
+        this.trigger('itemUnselected', item);
+    }
 };
 
 MultiSelleckt.prototype.toggleDisabled = function(){

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -514,6 +514,16 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
                     data: {}
                 });
             });
+
+            it('does not trigger an "itemUnselected" event when option.silent is passed', function(){
+                var spy = sandbox.spy();
+
+                multiSelleckt.on('trigger', spy);
+
+                multiSelleckt.unselectItem(1, {silent: true});
+
+                expect(spy.calledWith('itemUnselected')).toEqual(false);
+            });
         });
 
         describe('filtering', function(){


### PR DESCRIPTION
Back in https://github.com/BrandwatchLtd/selleckt/pull/78 I missed that `MultiSelleckt` also has an `unselectItem(...)`. There an `itemUnselected` is still triggering regardless if`options.silent` is  passes. 

This PR aligns the [behaviour of `selectItem(...)`](https://github.com/BrandwatchLtd/selleckt/blob/master/lib/MultiSelleckt.js#L105-L110) and `unselectItem(...)` when `options.silent` is passed.