### PR TITLE
NRP-4276 Add default search term option

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,14 @@ The following options can be passed to selleckt:
             </td>
         </tr>
         <tr>
+            <td>defaultSearchTerm</td>
+            <td>string</td>
+            <td>''</td>
+            <td>
+                If enableSearch is true, prefill search input with defaultSearchTerm.
+            </td>
+        </tr>
+        <tr>
             <td>hideSelectedItem</td>
             <td>boolean</td>
             <td>false</td>

--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -356,6 +356,7 @@ function SellecktPopup(options){
         highlightClass: 'highlighted',
         searchInputClass: 'search',
         showSearch: false,
+        defaultSearchTerm: '',
         maxHeightPopupPositioning: false
     });
 
@@ -370,6 +371,7 @@ function SellecktPopup(options){
 
     this.searchInputClass = settings.searchInputClass;
     this.showSearch = settings.showSearch;
+    this.defaultSearchTerm = settings.defaultSearchTerm;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
 
     templateUtils.cacheTemplate(this.template);
@@ -398,7 +400,8 @@ _.extend(SellecktPopup.prototype, {
         this._attachResizeHandler($opener);
 
         if (this.showSearch) {
-            $popup.find('.' + this.searchInputClass).focus();
+            var $input = $popup.find('.' + this.searchInputClass);
+            $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work
             $popup.find('.' + this.itemClass).first().attr('tabindex',-1).focus();
@@ -738,6 +741,7 @@ function SingleSelleckt(options){
         enableSearch: false,
         searchInputClass: 'search',
         searchThreshold: 0,
+        defaultSearchTerm: '',
         hideSelectedItem: false,
         maxHeightPopupPositioning: false
     });
@@ -765,6 +769,8 @@ function SingleSelleckt(options){
 
     this.showSearch = (settings.enableSearch &&
                         this.items.length > settings.searchThreshold);
+
+    this.defaultSearchTerm = settings.defaultSearchTerm;
 
     this.hideSelectedItem = settings.hideSelectedItem;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
@@ -811,6 +817,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.popup = this._makePopup();
+
+        if (this.defaultSearchTerm) {
+            this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+        }
 
         $sellecktEl.addClass('open').removeClass('closed');
 
@@ -861,6 +871,7 @@ _.extend(SingleSelleckt.prototype, {
             itemTextClass: this.itemTextClass,
             searchInputClass: this.searchInputClass,
             showSearch: this.showSearch,
+            defaultSearchTerm: this.defaultSearchTerm,
             maxHeightPopupPositioning: this.maxHeightPopupPositioning
         });
 

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -356,6 +356,7 @@ function SellecktPopup(options){
         highlightClass: 'highlighted',
         searchInputClass: 'search',
         showSearch: false,
+        defaultSearchTerm: '',
         maxHeightPopupPositioning: false
     });
 
@@ -370,6 +371,7 @@ function SellecktPopup(options){
 
     this.searchInputClass = settings.searchInputClass;
     this.showSearch = settings.showSearch;
+    this.defaultSearchTerm = settings.defaultSearchTerm;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
 
     templateUtils.cacheTemplate(this.template);
@@ -398,7 +400,8 @@ _.extend(SellecktPopup.prototype, {
         this._attachResizeHandler($opener);
 
         if (this.showSearch) {
-            $popup.find('.' + this.searchInputClass).focus();
+            var $input = $popup.find('.' + this.searchInputClass);
+            $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work
             $popup.find('.' + this.itemClass).first().attr('tabindex',-1).focus();
@@ -738,6 +741,7 @@ function SingleSelleckt(options){
         enableSearch: false,
         searchInputClass: 'search',
         searchThreshold: 0,
+        defaultSearchTerm: '',
         hideSelectedItem: false,
         maxHeightPopupPositioning: false
     });
@@ -765,6 +769,8 @@ function SingleSelleckt(options){
 
     this.showSearch = (settings.enableSearch &&
                         this.items.length > settings.searchThreshold);
+
+    this.defaultSearchTerm = settings.defaultSearchTerm;
 
     this.hideSelectedItem = settings.hideSelectedItem;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
@@ -811,6 +817,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.popup = this._makePopup();
+
+        if (this.defaultSearchTerm) {
+            this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+        }
 
         $sellecktEl.addClass('open').removeClass('closed');
 
@@ -861,6 +871,7 @@ _.extend(SingleSelleckt.prototype, {
             itemTextClass: this.itemTextClass,
             searchInputClass: this.searchInputClass,
             showSearch: this.showSearch,
+            defaultSearchTerm: this.defaultSearchTerm,
             maxHeightPopupPositioning: this.maxHeightPopupPositioning
         });
 

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -32,6 +32,7 @@ function SellecktPopup(options){
         highlightClass: 'highlighted',
         searchInputClass: 'search',
         showSearch: false,
+        defaultSearchTerm: '',
         maxHeightPopupPositioning: false
     });
 
@@ -46,6 +47,7 @@ function SellecktPopup(options){
 
     this.searchInputClass = settings.searchInputClass;
     this.showSearch = settings.showSearch;
+    this.defaultSearchTerm = settings.defaultSearchTerm;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
 
     templateUtils.cacheTemplate(this.template);
@@ -74,7 +76,8 @@ _.extend(SellecktPopup.prototype, {
         this._attachResizeHandler($opener);
 
         if (this.showSearch) {
-            $popup.find('.' + this.searchInputClass).focus();
+            var $input = $popup.find('.' + this.searchInputClass);
+            $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work
             $popup.find('.' + this.itemClass).first().attr('tabindex',-1).focus();

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -26,6 +26,7 @@ function SingleSelleckt(options){
         enableSearch: false,
         searchInputClass: 'search',
         searchThreshold: 0,
+        defaultSearchTerm: '',
         hideSelectedItem: false,
         maxHeightPopupPositioning: false
     });
@@ -53,6 +54,8 @@ function SingleSelleckt(options){
 
     this.showSearch = (settings.enableSearch &&
                         this.items.length > settings.searchThreshold);
+
+    this.defaultSearchTerm = settings.defaultSearchTerm;
 
     this.hideSelectedItem = settings.hideSelectedItem;
     this.maxHeightPopupPositioning = settings.maxHeightPopupPositioning;
@@ -99,6 +102,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.popup = this._makePopup();
+
+        if (this.defaultSearchTerm) {
+            this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+        }
 
         $sellecktEl.addClass('open').removeClass('closed');
 
@@ -149,6 +156,7 @@ _.extend(SingleSelleckt.prototype, {
             itemTextClass: this.itemTextClass,
             searchInputClass: this.searchInputClass,
             showSearch: this.showSearch,
+            defaultSearchTerm: this.defaultSearchTerm,
             maxHeightPopupPositioning: this.maxHeightPopupPositioning
         });
 

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -62,6 +62,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                     highlightClass: 'myHighlightClass',
                     searchInputClass: 'mySearchInputClass',
                     showSearch: true,
+                    defaultSearchTerm: 'myDefaultSearchTerm',
                     templateData: {foo: 'bar'},
                     maxHeightPopupPositioning: true
                 };
@@ -103,6 +104,10 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
 
             it('stores the showSearch passed in as this.showSearch', function(){
                 expect(popup.showSearch).toEqual(popupOptions.showSearch);
+            });
+
+            it('stores the defaultSearchTerm passed in as this.defaultSearchTerm', function(){
+                expect(popup.defaultSearchTerm).toEqual(popupOptions.defaultSearchTerm);
             });
 
             it('stores the templateData passed in as this.templateData', function(){
@@ -543,6 +548,25 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                 popup.open($opener, items);
 
                 expect($(document.activeElement).hasClass(popup.searchInputClass)).toEqual(true);
+            });
+
+            describe('when showSearch is true and defaultSearchTerm is set', function() {
+                beforeEach(function(){
+                    popup = new SellecktPopup({
+                        showSearch: true,
+                        defaultSearchTerm: 'myDefaultSearchTerm'
+                    });
+                    popup.open($opener, items);
+                });
+                it('renders the defaultSearchTerm in the searchInput', function(){
+                    expect(popup.$popup.find('.' + popup.searchInputClass).val()).toEqual('myDefaultSearchTerm');
+                });
+
+                it('selects the defaultSearchTerm in the searchInput', function(){
+                    var activeElement = document.activeElement;
+                    var text = activeElement.value.slice(activeElement.selectionStart, activeElement.selectionEnd);
+                    expect(text).toEqual('myDefaultSearchTerm');
+                });
             });
 
             it('focuses the first item if showSearch is false', function(){

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -1152,6 +1152,19 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
 
                     expect(selleckt.popup.$popup.find('.' + selleckt.searchInputClass).length).toEqual(0);
                 });
+
+                it('renders the defaultSearchTerm if settings.defaultSearchTerm is set and settings.enableSearch is true', function(){
+                    selleckt = new SingleSelleckt({
+                        $selectEl: $(selectHtml),
+                        enableSearch: true,
+                        defaultSearchTerm: 'myDefaultSearchTerm'
+                    });
+
+                    selleckt.render();
+                    selleckt._open();
+
+                    expect(selleckt.popup.$popup.find('.' + selleckt.searchInputClass).val()).toEqual('myDefaultSearchTerm');
+                });
             });
         });
 


### PR DESCRIPTION
In Analytics, we used `selleckt` with a `defaultSearchTerm` which was manually added to the search input.

It turned up that this introduces an inconsistency between the items displayed on popup creation and the ones displayed after the search is used, the latter being filtered and sorted by `_filterItems` in `_refreshPopupWithSearchHits`.

This PR introduces a `defaultSearchTerm` option which is taken into account when opening the popup and is then used to filter (and sort) the search items.