### PR TITLE
NRP-4276 Fix breaking line when enable search is misused

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -383,6 +383,7 @@ _.extend(SellecktPopup.prototype, {
         options = options || {};
 
         var $popup = this.$popup = createPopup();
+        var $input;
 
         if (options.css) {
             $popup.css(options.css);
@@ -398,8 +399,8 @@ _.extend(SellecktPopup.prototype, {
         this.bindEvents();
         this._attachResizeHandler($opener);
 
-        if (this.showSearch) {
-            var $input = $popup.find('.' + this.searchInputClass);
+        $input = $popup.find('.' + this.searchInputClass);
+        if (this.showSearch && $input.length) {
             $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -383,6 +383,7 @@ _.extend(SellecktPopup.prototype, {
         options = options || {};
 
         var $popup = this.$popup = createPopup();
+        var $input;
 
         if (options.css) {
             $popup.css(options.css);
@@ -398,8 +399,8 @@ _.extend(SellecktPopup.prototype, {
         this.bindEvents();
         this._attachResizeHandler($opener);
 
-        if (this.showSearch) {
-            var $input = $popup.find('.' + this.searchInputClass);
+        $input = $popup.find('.' + this.searchInputClass);
+        if (this.showSearch && $input.length) {
             $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work

--- a/lib/SellecktPopup.js
+++ b/lib/SellecktPopup.js
@@ -60,6 +60,7 @@ _.extend(SellecktPopup.prototype, {
         options = options || {};
 
         var $popup = this.$popup = createPopup();
+        var $input;
 
         if (options.css) {
             $popup.css(options.css);
@@ -75,8 +76,8 @@ _.extend(SellecktPopup.prototype, {
         this.bindEvents();
         this._attachResizeHandler($opener);
 
-        if (this.showSearch) {
-            var $input = $popup.find('.' + this.searchInputClass);
+        $input = $popup.find('.' + this.searchInputClass);
+        if (this.showSearch && $input.length) {
             $input.val(this.defaultSearchTerm).get(0).select();
         } else {
             //NB: set the tabindex so we can apply focus, which makes the key handling work

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -550,7 +550,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                 expect($(document.activeElement).hasClass(popup.searchInputClass)).toEqual(true);
             });
 
-            describe('when showSearch is true and defaultSearchTerm is set', function() {
+            describe('when showSearch is true, $input exists and defaultSearchTerm is set', function() {
                 beforeEach(function(){
                     popup = new SellecktPopup({
                         showSearch: true,
@@ -577,6 +577,25 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
 
                 expect(focusStub.calledOnce).toEqual(true);
                 expect(focusStub.thisValues[0].is(popup.$popup.find('.' + popup.itemClass).eq(0))).toEqual(true);
+            });
+
+            it('focuses the first item if $input is undefined', function(){
+                var focusStub = sandbox.stub($.fn, 'focus');
+                var ITEMS_CONTAINER = '<div class="{{itemsClass}}">' +
+                    '<ul class="{{itemslistClass}}">' +
+                        '{{#items}}' +
+                            '{{> item}}' +
+                        '{{/items}}' +
+                    '</ul>' +
+                '</div>';
+
+                popup = new SellecktPopup({
+                    template: ITEMS_CONTAINER,
+                    showSearch: true
+                });
+                popup.open($opener, items);
+
+                expect(focusStub.calledOnce).toEqual(true);
             });
 
             it('renders the items into the popup', function(){

--- a/test/specs/SellecktPopup.specs.js
+++ b/test/specs/SellecktPopup.specs.js
@@ -596,6 +596,7 @@ function sellecktPopupSpecs(SellecktPopup, templateUtils, $, _, Mustache){
                 popup.open($opener, items);
 
                 expect(focusStub.calledOnce).toEqual(true);
+                expect(focusStub.thisValues[0].is(popup.$popup.find('.' + popup.itemClass).eq(0))).toEqual(true);
             });
 
             it('renders the items into the popup', function(){


### PR DESCRIPTION
We noticed in Analytics one case where the `enableSearch` option was misused (the popup template did not contain any search input), which resulted in a javascript error.

This PR aims at fixing the line which throws an error so that other similar cases don't break.