### PR TITLE
NRP-4276 Fix query persistence

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -975,6 +975,7 @@ _.extend(SingleSelleckt.prototype, {
             itemsToShow = matchingItems;
         }
 
+        this.defaultSearchTerm = term;
         this.popup.refreshItems(itemsToShow);
 
         this.trigger('optionsFiltered', term);

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -975,6 +975,7 @@ _.extend(SingleSelleckt.prototype, {
             itemsToShow = matchingItems;
         }
 
+        this.defaultSearchTerm = term;
         this.popup.refreshItems(itemsToShow);
 
         this.trigger('optionsFiltered', term);

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -261,6 +261,7 @@ _.extend(SingleSelleckt.prototype, {
             itemsToShow = matchingItems;
         }
 
+        this.defaultSearchTerm = term;
         this.popup.refreshItems(itemsToShow);
 
         this.trigger('optionsFiltered', term);

--- a/test/specs/SingleSelleckt.specs.js
+++ b/test/specs/SingleSelleckt.specs.js
@@ -1300,6 +1300,27 @@ function singleSellecktSpecs(SingleSelleckt, templateUtils, $, _){
                 selleckt._close();
                 selleckt.destroy();
             });
+
+            it('resets the defaultSearchTerm when refreshing the search hits', function() {
+                selleckt = new SingleSelleckt({
+                    $selectEl: $('<select><option value="foo">foo</option><option value="bar">bar</option></select>'),
+                    enableSearch: true,
+                    defaultSearchTerm: 'query',
+                    searchThreshold: 0
+                });
+
+                selleckt.render();
+                selleckt._open();
+
+                expect(selleckt.defaultSearchTerm).toEqual('query');
+
+                selleckt._refreshPopupWithSearchHits('ba');
+
+                expect(selleckt.defaultSearchTerm).toEqual('ba');
+
+                selleckt._close();
+                selleckt.destroy();
+            });
         });
 
         describe('removal', function(){


### PR DESCRIPTION
When implementing the `defaultSearchTerm` option, a bug was introduced. 
Every time a search was done and the popup was re-opened, the last search term was getting overwritten by the default search term.

This PR fixes this bug by resetting the defaultSearchTerm to the last search performed.