### PR TITLE
Fix results filtering after unselect

### DIFF
--- a/dist/selleckt-legacy.js
+++ b/dist/selleckt-legacy.js
@@ -302,6 +302,8 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
 
     this.toggleDisabled();
 
+    this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+
     if (!options.silent) {
         this.updateOriginalSelect();
         this.trigger('itemUnselected', item);
@@ -977,7 +979,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.defaultSearchTerm = term;
-        this.popup.refreshItems(itemsToShow);
+
+        if (this.popup) {
+            this.popup.refreshItems(itemsToShow);
+        }
 
         this.trigger('optionsFiltered', term);
     },

--- a/dist/selleckt.js
+++ b/dist/selleckt.js
@@ -302,6 +302,8 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
 
     this.toggleDisabled();
 
+    this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+
     if (!options.silent) {
         this.updateOriginalSelect();
         this.trigger('itemUnselected', item);
@@ -977,7 +979,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.defaultSearchTerm = term;
-        this.popup.refreshItems(itemsToShow);
+
+        if (this.popup) {
+            this.popup.refreshItems(itemsToShow);
+        }
 
         this.trigger('optionsFiltered', term);
     },

--- a/lib/MultiSelleckt.js
+++ b/lib/MultiSelleckt.js
@@ -224,6 +224,8 @@ MultiSelleckt.prototype.unselectItem = function(item, options){
 
     this.toggleDisabled();
 
+    this._refreshPopupWithSearchHits(this.defaultSearchTerm);
+
     if (!options.silent) {
         this.updateOriginalSelect();
         this.trigger('itemUnselected', item);

--- a/lib/SingleSelleckt.js
+++ b/lib/SingleSelleckt.js
@@ -262,7 +262,10 @@ _.extend(SingleSelleckt.prototype, {
         }
 
         this.defaultSearchTerm = term;
-        this.popup.refreshItems(itemsToShow);
+
+        if (this.popup) {
+            this.popup.refreshItems(itemsToShow);
+        }
 
         this.trigger('optionsFiltered', term);
     },

--- a/test/specs/MultiSelleckt.specs.js
+++ b/test/specs/MultiSelleckt.specs.js
@@ -488,6 +488,16 @@ function multiSellecktSpecs(MultiSelleckt, templateUtils, $){
                 }]);
             });
 
+            it('refreshes the search hits when item the unselect link is clicked', function() {
+                var refreshPopupWithSearchHitsStub = sandbox.spy(multiSelleckt, '_refreshPopupWithSearchHits');
+                multiSelleckt.defaultSearchTerm = 'myquery';
+
+                $clickTarget.trigger('click');
+
+                expect(refreshPopupWithSearchHitsStub.callCount).toEqual(1);
+                expect(refreshPopupWithSearchHitsStub.args[0][0]).toEqual('myquery');
+            });
+
             it('triggers a change event on original select when item is removed', function(){
                 var changeHandler = sandbox.spy();
 


### PR DESCRIPTION
When the popup is open and an item is unselected by the user, the unselected item should be put back in the search items.

This PR fixes this behaviour.